### PR TITLE
Add runtime safety and protocol foundations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,9 @@ add_library(sfu_core STATIC
   src/memory/refcount.c
   src/util/ringbuffer.c
   src/util/log.c
+  src/util/metrics.c
+  src/cache/valkey_queue.c
+
   src/net/socket.c
   src/net/io_uring.c
   src/net/batch.c
@@ -78,13 +81,18 @@ add_library(sfu_core STATIC
   src/runtime/timer.c
   src/runtime/fanout.c
   src/runtime/worker.c
+  src/runtime/epoch_reclaimer.c
   src/runtime/scheduler.c
   src/runtime/signal.c
   src/runtime/routing_context.c
   src/congestion/gcc.c
   src/congestion/twcc_parser.c
+  src/rtp/rtp_packet.c
   src/rtp/rtx.c
+  src/rtp/rtx_build.c
   src/rtcp/rtcp_kf.c
+  src/rtcp/rtcp_compound.c
+  src/rtcp/rtcp_fb.c
 )
 
 target_include_directories(sfu_core PUBLIC

--- a/src/cache/valkey_queue.c
+++ b/src/cache/valkey_queue.c
@@ -1,0 +1,75 @@
+#include "valkey_queue.h"
+
+#include <errno.h>
+#include <string.h>
+
+int valkey_queue_init(valkey_queue_t *queue, valkey_queue_item_fn dispose,
+                      void *dispose_arg) {
+  if (!queue || !dispose) {
+    return EINVAL;
+  }
+  memset(queue, 0, sizeof(*queue));
+  queue->dispose = dispose;
+  queue->dispose_arg = dispose_arg;
+  return pthread_mutex_init(&queue->mutex, NULL);
+}
+
+valkey_queue_post_result_t valkey_queue_post(valkey_queue_t *queue, void *item) {
+  if (!queue || !item) {
+    return VALKEY_QUEUE_INVALID;
+  }
+  pthread_mutex_lock(&queue->mutex);
+  if (queue->closed) {
+    pthread_mutex_unlock(&queue->mutex);
+    return VALKEY_QUEUE_CLOSED;
+  }
+  if (queue->count == VALKEY_QUEUE_CAPACITY) {
+    pthread_mutex_unlock(&queue->mutex);
+    return VALKEY_QUEUE_FULL;
+  }
+  queue->items[queue->tail] = item;
+  queue->tail = (queue->tail + 1u) % VALKEY_QUEUE_CAPACITY;
+  queue->count++;
+  pthread_mutex_unlock(&queue->mutex);
+  return VALKEY_QUEUE_OK;
+}
+
+size_t valkey_queue_drain(valkey_queue_t *queue,
+                          valkey_queue_item_fn consume, void *consume_arg) {
+  if (!queue || !consume) {
+    return 0;
+  }
+  size_t drained = 0;
+  for (;;) {
+    pthread_mutex_lock(&queue->mutex);
+    if (queue->count == 0) {
+      pthread_mutex_unlock(&queue->mutex);
+      return drained;
+    }
+    void *item = queue->items[queue->head];
+    queue->items[queue->head] = NULL;
+    queue->head = (queue->head + 1u) % VALKEY_QUEUE_CAPACITY;
+    queue->count--;
+    pthread_mutex_unlock(&queue->mutex);
+    consume(item, consume_arg);
+    drained++;
+  }
+}
+
+void valkey_queue_close(valkey_queue_t *queue) {
+  if (!queue) {
+    return;
+  }
+  pthread_mutex_lock(&queue->mutex);
+  queue->closed = true;
+  pthread_mutex_unlock(&queue->mutex);
+}
+
+void valkey_queue_destroy_after_producers_stopped(valkey_queue_t *queue) {
+  if (!queue) {
+    return;
+  }
+  valkey_queue_close(queue);
+  valkey_queue_drain(queue, queue->dispose, queue->dispose_arg);
+  pthread_mutex_destroy(&queue->mutex);
+}

--- a/src/cache/valkey_queue.h
+++ b/src/cache/valkey_queue.h
@@ -1,0 +1,48 @@
+#ifndef VALKEY_QUEUE_H
+#define VALKEY_QUEUE_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <pthread.h>
+
+#define VALKEY_QUEUE_CAPACITY 256u
+
+typedef enum valkey_queue_post_result {
+  VALKEY_QUEUE_OK = 0,
+  VALKEY_QUEUE_FULL,
+  VALKEY_QUEUE_CLOSED,
+  VALKEY_QUEUE_INVALID,
+} valkey_queue_post_result_t;
+
+typedef void (*valkey_queue_item_fn)(void *item, void *arg);
+
+typedef struct valkey_queue {
+  pthread_mutex_t mutex;
+  size_t head;
+  size_t tail;
+  size_t count;
+  bool closed;
+  void *items[VALKEY_QUEUE_CAPACITY];
+  valkey_queue_item_fn dispose;
+  void *dispose_arg;
+} valkey_queue_t;
+
+int valkey_queue_init(valkey_queue_t *queue, valkey_queue_item_fn dispose,
+                      void *dispose_arg);
+
+/* OK transfers ownership. FULL/CLOSED/INVALID leave ownership with caller.
+ * NULL queue or item returns INVALID. */
+valkey_queue_post_result_t valkey_queue_post(valkey_queue_t *queue, void *item);
+
+/* Transfers each popped item to non-NULL consume. Invalid arguments return 0. */
+size_t valkey_queue_drain(valkey_queue_t *queue,
+                          valkey_queue_item_fn consume, void *consume_arg);
+
+/* Idempotently prevents subsequent posts. */
+void valkey_queue_close(valkey_queue_t *queue);
+
+/* Caller guarantees all producers are joined/stopped. Pending items use the
+ * dispose callback supplied at init. A second destroy call is prohibited. */
+void valkey_queue_destroy_after_producers_stopped(valkey_queue_t *queue);
+
+#endif

--- a/src/congestion/twcc_parser.c
+++ b/src/congestion/twcc_parser.c
@@ -1,8 +1,5 @@
 #include "twcc_parser.h"
-#include <arpa/inet.h>
-
-// Helper to read 24-bit integer
-static uint32_t read_24bit(const uint8_t *data) { return (data[0] << 16) | (data[1] << 8) | data[2]; }
+#include "util/netbytes.h"
 
 int sfu_twcc_parser_init(sfu_twcc_parser_t *parser, const uint8_t *data, size_t len) {
   // Basic RTCP Header (4) + Sender SSRC (4) + Media SSRC (4) + TWCC Header (8) = 20 bytes min
@@ -14,10 +11,10 @@ int sfu_twcc_parser_init(sfu_twcc_parser_t *parser, const uint8_t *data, size_t 
   parser->len = len;
 
   // TWCC specific fields start at offset 12 (after Sender SSRC and Media SSRC)
-  parser->base_seq = ntohs(*(uint16_t *)(data + 12));
-  parser->packet_status_count = ntohs(*(uint16_t *)(data + 14));
+  parser->base_seq = sfu_read_be16(data + 12);
+  parser->packet_status_count = sfu_read_be16(data + 14);
 
-  uint32_t reference_time_24b = read_24bit(data + 16);
+  uint32_t reference_time_24b = sfu_read_be24(data + 16);
   // Reference time is in multiples of 64ms
   parser->current_time_ms = (int64_t)reference_time_24b * 64;
 
@@ -34,7 +31,7 @@ int sfu_twcc_parser_init(sfu_twcc_parser_t *parser, const uint8_t *data, size_t 
   uint16_t temp_processed = 0;
 
   while (temp_processed < parser->packet_status_count && temp_offset + 2 <= len) {
-    uint16_t chunk = ntohs(*(uint16_t *)(data + temp_offset));
+    uint16_t chunk = sfu_read_be16(data + temp_offset);
     temp_offset += 2;
 
     if ((chunk & 0x8000) == 0) {
@@ -58,7 +55,7 @@ static uint8_t get_next_status(sfu_twcc_parser_t *parser) {
       return TWCC_STATUS_NOT_RECEIVED;  // EOF
     }
 
-    parser->current_chunk = ntohs(*(uint16_t *)(parser->data + parser->chunk_offset));
+    parser->current_chunk = sfu_read_be16(parser->data + parser->chunk_offset);
     parser->chunk_offset += 2;
 
     if ((parser->current_chunk & 0x8000) == 0) {
@@ -114,7 +111,7 @@ bool sfu_twcc_parser_next(sfu_twcc_parser_t *parser, gcc_packet_info_t *out_pkt)
       if (parser->delta_offset + 2 > parser->len) {
         return false;  // Corrupted
       }
-      int16_t delta_250us = (int16_t)ntohs(*(uint16_t *)(parser->data + parser->delta_offset));
+      int16_t delta_250us = (int16_t)sfu_read_be16(parser->data + parser->delta_offset);
       parser->delta_offset += 2;
       recv_delta_ms = (delta_250us * 250) / 1000;
     }

--- a/src/net/io_uring.c
+++ b/src/net/io_uring.c
@@ -224,6 +224,10 @@ static void handle_recv_cqe(sfu_ring_t *r, struct io_uring_cqe *cqe, sfu_packet_
 
   if (o->flags & MSG_TRUNC) {
     SFU_LOG_WARN("datagram truncated from %s:%u (bid=%u), dropping", peer_ip, peer_port, bid);
+    int mask = io_uring_buf_ring_mask(r->buf_count);
+    io_uring_buf_ring_add(r->buf_ring, buf, r->buf_size, bid, mask, 0);
+    io_uring_buf_ring_advance(r->buf_ring, 1);
+    goto maybe_rearm;
   }
 
   sfu_packet_t *pkt = sfu_packet_pool_alloc_meta(pp);

--- a/src/peer/session.c
+++ b/src/peer/session.c
@@ -73,52 +73,65 @@ static uint32_t addr_probe(sfu_hash_slot_t *table, uint32_t cap, uint32_t hash, 
   return for_insert && first_deleted >= 0 ? (uint32_t)first_deleted : SFU_HASH_EMPTY;
 }
 
+static void sfu_session_free_resources(sfu_peer_session_t *s) {
+  if (!s) {
+    return;
+  }
+
+  if (s->active) {
+    if (s->state == SFU_SESSION_ESTABLISHED) {
+      sfu_srtp_ctx_destroy(&s->srtp);
+    }
+    if (s->cold) {
+      sfu_dtls_conn_destroy(&s->cold->dtls);
+    }
+  }
+
+  if (s->receivers) {
+    for (uint32_t i = 0; i < s->receiver_capacity; i++) {
+      SFU_FREE(s->receivers[i]);
+      s->receivers[i] = NULL;
+    }
+    SFU_FREE(s->receivers);
+    s->receivers = NULL;
+  }
+  s->receiver_capacity = 0;
+
+  if (s->rtx_cache) {
+    sfu_rtx_cache_destroy(s->rtx_cache);
+    SFU_FREE(s->rtx_cache);
+    s->rtx_cache = NULL;
+  }
+  if (s->gcc_ctx) {
+    SFU_FREE(s->gcc_ctx);
+    s->gcc_ctx = NULL;
+  }
+  if (s->twcc_history) {
+    SFU_FREE(s->twcc_history);
+    s->twcc_history = NULL;
+  }
+  if (s->scheduler) {
+    SFU_FREE(s->scheduler);
+    s->scheduler = NULL;
+  }
+  if (s->cold) {
+    SFU_FREE(s->cold);
+    s->cold = NULL;
+  }
+}
+
 void sfu_session_table_destroy(sfu_session_table_t *t) {
   pthread_mutex_lock(&t->lock);
 
   for (uint32_t i = 0; i < t->count; i++) {
-    if (!t->sessions[i]) {
-      continue;
-    }
-
-    if (t->sessions[i]->active) {
-      if (t->sessions[i]->state == SFU_SESSION_ESTABLISHED) {
-        sfu_srtp_ctx_destroy(&t->sessions[i]->srtp);
-      }
-      sfu_dtls_conn_destroy(&t->sessions[i]->cold->dtls);
-    }
-    if (t->sessions[i]->receivers) {
-      for (uint32_t j = 0; j < t->sessions[i]->receiver_capacity; j++) {
-        SFU_FREE(t->sessions[i]->receivers[j]);
-      }
-      SFU_FREE(t->sessions[i]->receivers);
-    }
     sfu_peer_session_t *s = t->sessions[i];
     if (!s) {
       continue;
     }
 
-    SFU_FREE(s->receivers);
-
-    /* Free RTX cache if allocated */
-    if (s->rtx_cache) {
-      sfu_rtx_cache_destroy(s->rtx_cache);
-      SFU_FREE(s->rtx_cache);
-    }
-
-    /* Free other context pointers if allocated */
-    if (s->gcc_ctx) {
-      SFU_FREE(s->gcc_ctx);
-    }
-    if (s->twcc_history) {
-      SFU_FREE(s->twcc_history);
-    }
-    if (s->scheduler) {
-      SFU_FREE(s->scheduler);
-    }
-
-    SFU_FREE(s->cold);
+    sfu_session_free_resources(s);
     SFU_FREE(s);
+    t->sessions[i] = NULL;
   }
 
   SFU_FREE(t->sessions);
@@ -256,32 +269,30 @@ sfu_peer_session_t *sfu_session_table_get_or_create(sfu_session_table_t *t, cons
 
   s->rtx_cache = SFU_CALLOC(1, sizeof(sfu_rtx_cache_t));
   if (s->rtx_cache) {
-    sfu_rtx_cache_init(s->rtx_cache);
+    if (sfu_rtx_cache_init(s->rtx_cache) != 0) {
+      SFU_FREE(s->rtx_cache);
+      s->rtx_cache = NULL;
+    }
+  }
+  if (!s->rtx_cache) {
+    SFU_LOG_ERROR("failed to init RTX cache for new peer session");
+
+    sfu_session_free_resources(s);
+    SFU_FREE(s);
+    t->sessions[index] = NULL;
+
+    if (index + 1 == t->count) {
+      t->count--;
+    }
+
+    pthread_mutex_unlock(&t->lock);
+    return NULL;
   }
 
   if (sfu_dtls_conn_init(&s->cold->dtls, t->dtls_ctx) != 0) {
     SFU_LOG_ERROR("failed to init DTLS connection for new peer session");
 
-    SFU_FREE(s->receivers);
-
-    if (s->cold) {
-      SFU_FREE(s->cold);
-    }
-
-    if (s->gcc_ctx) {
-      SFU_FREE(s->gcc_ctx);
-    }
-    if (s->twcc_history) {
-      SFU_FREE(s->twcc_history);
-    }
-    if (s->scheduler) {
-      SFU_FREE(s->scheduler);
-    }
-    if (s->rtx_cache) {
-      sfu_rtx_cache_destroy(s->rtx_cache);
-      SFU_FREE(s->rtx_cache);
-    }
-
+    sfu_session_free_resources(s);
     SFU_FREE(s);
     t->sessions[index] = NULL;
 
@@ -363,41 +374,7 @@ void sfu_session_table_remove(sfu_session_table_t *t, sfu_peer_session_t *s) {
     }
   }
   if (s->active) {
-    if (s->state == SFU_SESSION_ESTABLISHED) {
-      sfu_srtp_ctx_destroy(&s->srtp);
-    }
-    sfu_dtls_conn_destroy(&s->cold->dtls);
-
-    if (s->receivers) {
-      for (uint32_t i = 0; i < s->receiver_capacity; i++) {
-        SFU_FREE(s->receivers[i]);
-      }
-      SFU_FREE(s->receivers);
-      s->receivers = NULL;
-      s->receiver_capacity = 0;
-    }
-
-    /* Free RTX cache if allocated */
-    if (s->rtx_cache) {
-      sfu_rtx_cache_destroy(s->rtx_cache);
-      SFU_FREE(s->rtx_cache);
-      s->rtx_cache = NULL;
-    }
-
-    /* Free other context pointers if allocated */
-    if (s->gcc_ctx) {
-      SFU_FREE(s->gcc_ctx);
-      s->gcc_ctx = NULL;
-    }
-    if (s->twcc_history) {
-      SFU_FREE(s->twcc_history);
-      s->twcc_history = NULL;
-    }
-    if (s->scheduler) {
-      SFU_FREE(s->scheduler);
-      s->scheduler = NULL;
-    }
-
+    sfu_session_free_resources(s);
     s->active = false;
     s->state = SFU_SESSION_FAILED;
   }

--- a/src/protocol/signaling/json_lite.c
+++ b/src/protocol/signaling/json_lite.c
@@ -4,6 +4,9 @@
 #include <string.h>
 
 int sfu_json_extract_string(const char *json, size_t json_len, const char *field, char *out, size_t out_cap) {
+  if (out == NULL || out_cap == 0) {
+    return -1;
+  }
   char needle[128];
   int needle_len = snprintf(needle, sizeof(needle), "\"%s\"", field);
   if (needle_len < 0 || (size_t)needle_len >= sizeof(needle) || (size_t)needle_len > json_len) {
@@ -60,6 +63,9 @@ int sfu_json_extract_string(const char *json, size_t json_len, const char *field
 }
 
 int sfu_json_escape(const char *value, size_t value_len, char *out, size_t out_cap) {
+  if (out == NULL || out_cap == 0) {
+    return -1;
+  }
   size_t out_len = 0;
   for (size_t i = 0; i < value_len; i++) {
     char c = value[i];

--- a/src/protocol/signaling/json_lite.h
+++ b/src/protocol/signaling/json_lite.h
@@ -3,6 +3,9 @@
 
 #include <stddef.h>
 
+/* Output buffer capacity must be >= 1. On success, return value is the number
+ * of bytes written excluding the trailing NUL. Rejects out == NULL or
+ * out_cap == 0 with -1 before any write (including the trailing NUL). */
 int sfu_json_extract_string(const char *json, size_t json_len, const char *field, char *out, size_t out_cap);
 int sfu_json_escape(const char *value, size_t value_len, char *out, size_t out_cap);
 

--- a/src/room/room_media_graph.c
+++ b/src/room/room_media_graph.c
@@ -38,7 +38,9 @@ static sfu_receiver_slot_t *alloc_receiver_slot(sfu_peer_session_t *peer, sfu_sc
 
   if (old_array) {
     if (scheduler) {
-      sfu_scheduler_retire_ptr(scheduler, old_array);
+      if (!sfu_scheduler_retire_ptr(scheduler, old_array)) {
+        SFU_LOG_ERROR("alloc_receiver_slot: retirement failed for old_array=%p; leaking safely", (void *)old_array);
+      }
     } else {
       SFU_LOG_ERROR("alloc_receiver_slot: no scheduler to retire old_array=%p, leaking", (void *)old_array);
     }

--- a/src/rtcp/rtcp_compound.c
+++ b/src/rtcp/rtcp_compound.c
@@ -1,0 +1,56 @@
+#include "rtcp/rtcp_compound.h"
+
+#include <string.h>
+
+#include "util/netbytes.h"
+
+void sfu_rtcp_compound_iter_init(sfu_rtcp_compound_iter *iter, const uint8_t *packet,
+                                 size_t packet_len) {
+  iter->next = packet;
+  iter->remaining = packet_len;
+  iter->malformed = 0;
+}
+
+static sfu_rtcp_compound_result malformed(sfu_rtcp_compound_iter *iter) {
+  iter->malformed = 1;
+  iter->remaining = 0;
+  return SFU_RTCP_COMPOUND_MALFORMED;
+}
+
+sfu_rtcp_compound_result sfu_rtcp_compound_iter_next(sfu_rtcp_compound_iter *iter,
+                                                     sfu_rtcp_member_view *view) {
+  if (iter == NULL || view == NULL) return SFU_RTCP_COMPOUND_MALFORMED;
+  if (iter->malformed) return SFU_RTCP_COMPOUND_MALFORMED;
+  if (iter->remaining == 0) return SFU_RTCP_COMPOUND_END;
+  if (iter->next == NULL || iter->remaining < 4) return malformed(iter);
+
+  const uint8_t *member = iter->next;
+  const uint8_t first = member[0];
+  if ((first >> 6) != 2) return malformed(iter);
+
+  const uint16_t words_minus_one = sfu_read_be16(member + 2);
+  const size_t member_bytes = ((size_t)words_minus_one + 1u) * 4u;
+  if (member_bytes < 8 || member_bytes > iter->remaining) return malformed(iter);
+
+  size_t logical_bytes = member_bytes;
+  if ((first & 0x20u) != 0) {
+    const uint8_t padding = member[member_bytes - 1];
+    const size_t payload_bytes = member_bytes - 4;
+    if (padding == 0 || (size_t)padding > payload_bytes) return malformed(iter);
+    logical_bytes -= padding;
+    if (logical_bytes < 8) return malformed(iter);
+  }
+
+  memset(view, 0, sizeof(*view));
+  view->member = member;
+  view->member_len = logical_bytes;
+  view->fmt_count = first & 0x1fu;
+  view->pt = member[1];
+  view->sender_ssrc = sfu_read_be32(member + 4);
+  view->body = member + 8;
+  view->body_len = logical_bytes - 8;
+
+  iter->next += member_bytes;
+  iter->remaining -= member_bytes;
+  return SFU_RTCP_COMPOUND_ITEM;
+}

--- a/src/rtcp/rtcp_compound.h
+++ b/src/rtcp/rtcp_compound.h
@@ -1,0 +1,40 @@
+#ifndef SFU_RTCP_COMPOUND_H
+#define SFU_RTCP_COMPOUND_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+typedef enum {
+  SFU_RTCP_COMPOUND_MALFORMED = -1,
+  SFU_RTCP_COMPOUND_END = 0,
+  SFU_RTCP_COMPOUND_ITEM = 1,
+} sfu_rtcp_compound_result;
+
+typedef struct {
+  const uint8_t *member;
+  size_t member_len;
+  uint8_t fmt_count;
+  uint8_t pt;
+  uint32_t sender_ssrc;
+  const uint8_t *body;
+  size_t body_len;
+} sfu_rtcp_member_view;
+
+typedef struct {
+  const uint8_t *next;
+  size_t remaining;
+  int malformed;
+} sfu_rtcp_compound_iter;
+
+void sfu_rtcp_compound_iter_init(sfu_rtcp_compound_iter *iter, const uint8_t *packet,
+                                 size_t packet_len);
+
+/*
+ * Members must be at least eight bytes so sender_ssrc is always available.
+ * member_len and body_len exclude any RTCP padding; member points at the exact
+ * bounded member and body starts immediately after the sender SSRC.
+ */
+sfu_rtcp_compound_result sfu_rtcp_compound_iter_next(sfu_rtcp_compound_iter *iter,
+                                                     sfu_rtcp_member_view *view);
+
+#endif /* SFU_RTCP_COMPOUND_H */

--- a/src/rtcp/rtcp_fb.c
+++ b/src/rtcp/rtcp_fb.c
@@ -1,0 +1,47 @@
+#include "rtcp/rtcp_fb.h"
+
+#include "util/netbytes.h"
+
+bool sfu_rtcp_parse_pli(const sfu_rtcp_member_view *member, sfu_rtcp_pli *pli) {
+  if (member == NULL || pli == NULL || member->member == NULL || member->body == NULL)
+    return false;
+  if (member->pt != 206 || member->fmt_count != 1 || member->member_len != 12 ||
+      member->body_len != 4 || member->body != member->member + 8)
+    return false;
+
+  pli->sender_ssrc = member->sender_ssrc;
+  pli->media_ssrc = sfu_read_be32(member->body);
+  return true;
+}
+
+bool sfu_rtcp_parse_fir(const sfu_rtcp_member_view *member, sfu_rtcp_fir *fir) {
+  if (member == NULL || fir == NULL || member->member == NULL || member->body == NULL)
+    return false;
+  if (member->pt != 206 || member->fmt_count != 4 || member->member_len < 20 ||
+      member->body_len < 12 || member->body != member->member + 8 ||
+      member->member_len != member->body_len + 8 ||
+      (member->body_len - 4) % 8 != 0)
+    return false;
+
+  const size_t count = (member->body_len - 4) / 8;
+  for (size_t i = 0; i < count; ++i) {
+    const uint8_t *entry = member->body + 4 + i * 8;
+    if (entry[5] != 0 || entry[6] != 0 || entry[7] != 0) return false;
+  }
+
+  fir->sender_ssrc = member->sender_ssrc;
+  fir->media_ssrc = sfu_read_be32(member->body);
+  fir->fci = member->body + 4;
+  fir->entry_count = count;
+  return true;
+}
+
+bool sfu_rtcp_fir_entry_at(const sfu_rtcp_fir *fir, size_t index,
+                           sfu_rtcp_fir_entry *entry) {
+  if (fir == NULL || entry == NULL || fir->fci == NULL || index >= fir->entry_count)
+    return false;
+  const uint8_t *p = fir->fci + index * 8;
+  entry->target_ssrc = sfu_read_be32(p);
+  entry->sequence_number = p[4];
+  return true;
+}

--- a/src/rtcp/rtcp_fb.h
+++ b/src/rtcp/rtcp_fb.h
@@ -1,0 +1,32 @@
+#ifndef SFU_RTCP_FB_H
+#define SFU_RTCP_FB_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "rtcp/rtcp_compound.h"
+
+typedef struct {
+  uint32_t sender_ssrc;
+  uint32_t media_ssrc;
+} sfu_rtcp_pli;
+
+typedef struct {
+  uint32_t sender_ssrc;
+  uint32_t media_ssrc;
+  const uint8_t *fci;
+  size_t entry_count;
+} sfu_rtcp_fir;
+
+typedef struct {
+  uint32_t target_ssrc;
+  uint8_t sequence_number;
+} sfu_rtcp_fir_entry;
+
+bool sfu_rtcp_parse_pli(const sfu_rtcp_member_view *member, sfu_rtcp_pli *pli);
+bool sfu_rtcp_parse_fir(const sfu_rtcp_member_view *member, sfu_rtcp_fir *fir);
+bool sfu_rtcp_fir_entry_at(const sfu_rtcp_fir *fir, size_t index,
+                           sfu_rtcp_fir_entry *entry);
+
+#endif /* SFU_RTCP_FB_H */

--- a/src/rtp/rtp_packet.c
+++ b/src/rtp/rtp_packet.c
@@ -1,0 +1,95 @@
+#include "rtp/rtp_packet.h"
+
+#include <string.h>
+
+#include "util/netbytes.h"
+
+#define RTP_FIXED_HEADER_LEN 12u
+
+bool sfu_rtp_packet_parse(const uint8_t *data, size_t len, sfu_rtp_packet_t *packet) {
+  size_t header_len;
+  size_t payload_span;
+
+  if (!data || !packet || len < RTP_FIXED_HEADER_LEN) {
+    return false;
+  }
+
+  memset(packet, 0, sizeof(*packet));
+  packet->version = data[0] >> 6;
+  if (packet->version != 2) {
+    return false;
+  }
+
+  packet->padding = (data[0] & 0x20u) != 0;
+  packet->extension = (data[0] & 0x10u) != 0;
+  packet->csrc_count = data[0] & 0x0fu;
+  packet->marker = (data[1] & 0x80u) != 0;
+  packet->payload_type = data[1] & 0x7fu;
+  packet->sequence_number = sfu_read_be16(data + 2);
+  packet->timestamp = sfu_read_be32(data + 4);
+  packet->ssrc = sfu_read_be32(data + 8);
+
+  header_len = RTP_FIXED_HEADER_LEN + (size_t)packet->csrc_count * 4u;
+  if (header_len > len) {
+    return false;
+  }
+
+  if (packet->extension) {
+    size_t extension_bytes;
+    if (len - header_len < 4u) {
+      return false;
+    }
+    packet->extension_profile = sfu_read_be16(data + header_len);
+    extension_bytes = (size_t)sfu_read_be16(data + header_len + 2u) * 4u;
+    header_len += 4u;
+    if (extension_bytes > len - header_len) {
+      return false;
+    }
+    packet->extension_data = data + header_len;
+    packet->extension_length = extension_bytes;
+    header_len += extension_bytes;
+  }
+
+  packet->header_len = header_len;
+  packet->payload = data + header_len;
+  payload_span = len - header_len;
+  packet->payload_len = payload_span;
+
+  if (packet->padding) {
+    uint8_t padding_count;
+    if (payload_span == 0) {
+      return false;
+    }
+    padding_count = data[len - 1u];
+    if (padding_count == 0 || (size_t)padding_count > payload_span) {
+      return false;
+    }
+    packet->payload_len -= padding_count;
+  }
+
+  return true;
+}
+
+bool sfu_rtp_packet_set_pt(uint8_t *data, size_t len, uint8_t payload_type) {
+  if (!data || len < RTP_FIXED_HEADER_LEN || payload_type > 127u) {
+    return false;
+  }
+  data[1] = (uint8_t)((data[1] & 0x80u) | payload_type);
+  return true;
+}
+
+bool sfu_rtp_packet_set_seq(uint8_t *data, size_t len, uint16_t sequence_number) {
+  if (!data || len < RTP_FIXED_HEADER_LEN) {
+    return false;
+  }
+  sfu_write_be16(data + 2, sequence_number);
+  return true;
+}
+
+bool sfu_rtp_packet_set_ssrc(uint8_t *data, size_t len, uint32_t ssrc) {
+  if (!data || len < RTP_FIXED_HEADER_LEN) {
+    return false;
+  }
+  sfu_write_be32(data + 8, ssrc);
+  return true;
+}

--- a/src/rtp/rtp_packet.h
+++ b/src/rtp/rtp_packet.h
@@ -1,0 +1,32 @@
+#ifndef SFU_RTP_PACKET_H
+#define SFU_RTP_PACKET_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+typedef struct sfu_rtp_packet {
+  uint8_t version;
+  bool padding;
+  bool extension;
+  uint8_t csrc_count;
+  bool marker;
+  uint8_t payload_type;
+  uint16_t sequence_number;
+  uint32_t timestamp;
+  uint32_t ssrc;
+  uint16_t extension_profile;
+  const uint8_t *extension_data;
+  size_t extension_length;
+  size_t header_len;
+  const uint8_t *payload;
+  size_t payload_len;
+} sfu_rtp_packet_t;
+
+bool sfu_rtp_packet_parse(const uint8_t *data, size_t len, sfu_rtp_packet_t *packet);
+
+bool sfu_rtp_packet_set_pt(uint8_t *data, size_t len, uint8_t payload_type);
+bool sfu_rtp_packet_set_seq(uint8_t *data, size_t len, uint16_t sequence_number);
+bool sfu_rtp_packet_set_ssrc(uint8_t *data, size_t len, uint32_t ssrc);
+
+#endif /* SFU_RTP_PACKET_H */

--- a/src/rtp/rtx.c
+++ b/src/rtp/rtx.c
@@ -53,21 +53,36 @@ bool sfu_nack_parser_next(sfu_nack_parser_t *parser, uint16_t *lost_seq) {
   return false;  // No more lost packets in this RTCP message
 }
 
-// Initialize the cache and pre-allocate packet buffers
-void sfu_rtx_cache_init(sfu_rtx_cache_t *cache) {
+// Initialize the cache and pre-allocate packet buffers.
+// Returns 0 on success, -1 if any entry buffer allocation fails (cache left
+// cleaned so the caller can free the cache struct itself).
+int sfu_rtx_cache_init(sfu_rtx_cache_t *cache) {
   memset(cache, 0, sizeof(sfu_rtx_cache_t));
   cache->next_rtx_seq = 0;
 
   // Pre-allocate memory for the packet copies to avoid malloc() in the hot path.
-  // 1024 entries * 1500 bytes = ~1.5MB per subscriber.
+  // 1024 entries * SFU_MAX_PAYLOAD_SIZE bytes per subscriber.
   for (int i = 0; i < SFU_RTX_CACHE_SIZE; i++) {
     cache->entries[i].data = (uint8_t *)SFU_CALLOC(1, SFU_MAX_PAYLOAD_SIZE);
+    if (!cache->entries[i].data) {
+      // Free already-allocated buffers and leave the cache zeroed/invalid.
+      for (int j = 0; j < i; j++) {
+        SFU_FREE(cache->entries[j].data);
+        cache->entries[j].data = NULL;
+      }
+      return -1;
+    }
     cache->entries[i].valid = false;
   }
+  return 0;
 }
 
 void sfu_rtx_cache_put(sfu_rtx_cache_t *cache, uint16_t seq, const uint8_t *data, uint32_t len, uint32_t rtx_ssrc, uint8_t rtx_pt) {
-  if (len > SFU_MAX_PAYLOAD_SIZE) {
+  // RTX rebuild inserts a 2-byte OSN before the original payload, so the
+  // cached packet must leave room for that expansion. SRTP overhead is
+  // bounded separately by the caller's protect call, which already receives
+  // the destination buffer capacity (cap).
+  if (len + 2 > SFU_MAX_PAYLOAD_SIZE) {
     return;
   }
   uint32_t idx = seq & SFU_RTX_CACHE_MASK;

--- a/src/rtp/rtx.h
+++ b/src/rtp/rtx.h
@@ -30,7 +30,7 @@ typedef struct {
   int bit_index;
 } sfu_nack_parser_t;
 
-void sfu_rtx_cache_init(sfu_rtx_cache_t *cache);
+int sfu_rtx_cache_init(sfu_rtx_cache_t *cache);
 void sfu_rtx_cache_put(sfu_rtx_cache_t *cache, uint16_t seq, const uint8_t *data, uint32_t len, uint32_t rtx_ssrc, uint8_t rtx_pt);
 bool sfu_rtx_cache_get(sfu_rtx_cache_t *cache, uint16_t seq, uint8_t *out_data, uint32_t *out_len, uint32_t *out_rtx_ssrc, uint8_t *out_rtx_pt);
 void sfu_rtx_cache_destroy(sfu_rtx_cache_t *cache);

--- a/src/rtp/rtx_build.c
+++ b/src/rtp/rtx_build.c
@@ -1,0 +1,37 @@
+#include "rtp/rtx_build.h"
+
+#include <string.h>
+
+#include "rtp/rtp_packet.h"
+#include "util/netbytes.h"
+
+bool sfu_rtx_build(const uint8_t *orig, size_t orig_len, uint8_t rtx_pt,
+                   uint16_t rtx_seq, uint32_t rtx_ssrc, uint8_t *out,
+                   size_t out_cap, size_t *out_len) {
+  sfu_rtp_packet_t packet;
+  size_t built_len;
+
+  if (!orig || !out || !out_len || rtx_pt > 127u ||
+      !sfu_rtp_packet_parse(orig, orig_len, &packet) ||
+      orig_len < packet.header_len || orig_len > SIZE_MAX - 2u ||
+      packet.payload_len > SIZE_MAX - packet.header_len - 2u) {
+    return false;
+  }
+
+  built_len = packet.header_len + 2u + packet.payload_len;
+  /* Conservatively require room for the original packet plus the OSN before
+   * writing, even when stripping original padding makes built_len smaller. */
+  if (orig_len + 2u > out_cap) {
+    return false;
+  }
+
+  memcpy(out, orig, packet.header_len);
+  out[0] &= (uint8_t)~0x20u;
+  (void)sfu_rtp_packet_set_pt(out, packet.header_len, rtx_pt);
+  (void)sfu_rtp_packet_set_seq(out, packet.header_len, rtx_seq);
+  (void)sfu_rtp_packet_set_ssrc(out, packet.header_len, rtx_ssrc);
+  sfu_write_be16(out + packet.header_len, packet.sequence_number);
+  memcpy(out + packet.header_len + 2u, packet.payload, packet.payload_len);
+  *out_len = built_len;
+  return true;
+}

--- a/src/rtp/rtx_build.h
+++ b/src/rtp/rtx_build.h
@@ -1,0 +1,24 @@
+#ifndef SFU_RTP_RTX_BUILD_H
+#define SFU_RTP_RTX_BUILD_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/*
+ * Build a plaintext RFC 4588 RTX packet in out.
+ *
+ * The complete original RTP header (including CSRCs and header extension) is
+ * preserved, then PT, sequence number and SSRC are replaced with the RTX
+ * values. The original sequence number (OSN) is prepended to the media
+ * payload. Original RTP padding is deliberately stripped and the output P bit
+ * is cleared; padding bytes are not part of the retransmitted payload.
+ *
+ * On failure neither out nor *out_len is modified. orig and out must refer to
+ * non-overlapping storage.
+ */
+bool sfu_rtx_build(const uint8_t *orig, size_t orig_len, uint8_t rtx_pt,
+                   uint16_t rtx_seq, uint32_t rtx_ssrc, uint8_t *out,
+                   size_t out_cap, size_t *out_len);
+
+#endif /* SFU_RTP_RTX_BUILD_H */

--- a/src/runtime/epoch_reclaimer.c
+++ b/src/runtime/epoch_reclaimer.c
@@ -1,0 +1,119 @@
+#include "runtime/epoch_reclaimer.h"
+
+#include <string.h>
+
+#include "util/log.h"
+
+int sfu_epoch_reclaimer_init(sfu_epoch_reclaimer_t *reclaimer, uint32_t worker_count,
+                             sfu_epoch_generation_fn generation, void *generation_context) {
+  if (!reclaimer || worker_count == 0 || worker_count > SFU_MAX_WORKERS || !generation) {
+    SFU_LOG_ERROR("epoch_reclaimer: invalid init args");
+    return -1;
+  }
+
+  memset(reclaimer, 0, sizeof(*reclaimer));
+  if (pthread_mutex_init(&reclaimer->lock, NULL) != 0) {
+    SFU_LOG_ERROR("epoch_reclaimer: failed to init lock");
+    return -1;
+  }
+
+  reclaimer->generation = generation;
+  reclaimer->generation_context = generation_context;
+  reclaimer->worker_count = worker_count;
+
+  for (uint32_t i = 0; i < SFU_EPOCH_RECLAIMER_CAPACITY; i++) {
+    reclaimer->nodes[i].next = reclaimer->free_nodes;
+    reclaimer->free_nodes = &reclaimer->nodes[i];
+  }
+
+  return 0;
+}
+
+bool sfu_epoch_reclaimer_retire(sfu_epoch_reclaimer_t *reclaimer, void *ptr,
+                                sfu_epoch_destructor_fn destructor) {
+  if (!reclaimer || !ptr || !destructor) {
+    return false;
+  }
+
+  pthread_mutex_lock(&reclaimer->lock);
+  if (!reclaimer->free_nodes) {
+    pthread_mutex_unlock(&reclaimer->lock);
+    return false;
+  }
+
+  sfu_epoch_retire_node_t *node = reclaimer->free_nodes;
+  reclaimer->free_nodes = node->next;
+  node->ptr = ptr;
+  node->destructor = destructor;
+  for (uint32_t i = 0; i < reclaimer->worker_count; i++) {
+    node->worker_generations[i] = reclaimer->generation(reclaimer->generation_context, i);
+  }
+  node->next = reclaimer->pending;
+  reclaimer->pending = node;
+  pthread_mutex_unlock(&reclaimer->lock);
+
+  return true;
+}
+
+uint32_t sfu_epoch_reclaimer_sweep(sfu_epoch_reclaimer_t *reclaimer) {
+  if (!reclaimer) {
+    return 0;
+  }
+
+  uint32_t reclaimed = 0;
+  sfu_epoch_retire_node_t *ready = NULL;
+
+  pthread_mutex_lock(&reclaimer->lock);
+  sfu_epoch_retire_node_t **cursor = &reclaimer->pending;
+  while (*cursor) {
+    sfu_epoch_retire_node_t *node = *cursor;
+    bool safe = true;
+    for (uint32_t i = 0; i < reclaimer->worker_count; i++) {
+      if (reclaimer->generation(reclaimer->generation_context, i) == node->worker_generations[i]) {
+        safe = false;
+        break;
+      }
+    }
+
+    if (safe) {
+      *cursor = node->next;
+      node->next = ready;
+      ready = node;
+      reclaimed++;
+    } else {
+      cursor = &node->next;
+    }
+  }
+  pthread_mutex_unlock(&reclaimer->lock);
+
+  while (ready) {
+    sfu_epoch_retire_node_t *node = ready;
+    ready = node->next;
+    node->destructor(node->ptr);
+    pthread_mutex_lock(&reclaimer->lock);
+    node->next = reclaimer->free_nodes;
+    reclaimer->free_nodes = node;
+    pthread_mutex_unlock(&reclaimer->lock);
+  }
+
+  return reclaimed;
+}
+
+void sfu_epoch_reclaimer_destroy_after_quiescence(sfu_epoch_reclaimer_t *reclaimer) {
+  if (!reclaimer) {
+    return;
+  }
+
+  pthread_mutex_lock(&reclaimer->lock);
+  sfu_epoch_retire_node_t *node = reclaimer->pending;
+  reclaimer->pending = NULL;
+  pthread_mutex_unlock(&reclaimer->lock);
+
+  while (node) {
+    sfu_epoch_retire_node_t *next = node->next;
+    node->destructor(node->ptr);
+    node = next;
+  }
+
+  pthread_mutex_destroy(&reclaimer->lock);
+}

--- a/src/runtime/epoch_reclaimer.h
+++ b/src/runtime/epoch_reclaimer.h
@@ -1,0 +1,42 @@
+#ifndef SFU_RUNTIME_EPOCH_RECLAIMER_H
+#define SFU_RUNTIME_EPOCH_RECLAIMER_H
+
+#include <stdbool.h>
+#include <pthread.h>
+#include <stdint.h>
+#include "sfu/config.h"
+
+#define SFU_EPOCH_RECLAIMER_CAPACITY 256
+
+typedef uint64_t (*sfu_epoch_generation_fn)(void *context, uint32_t worker_index);
+typedef void (*sfu_epoch_destructor_fn)(void *ptr);
+
+typedef struct sfu_epoch_retire_node {
+  void *ptr;
+  sfu_epoch_destructor_fn destructor;
+  uint64_t worker_generations[SFU_MAX_WORKERS];
+  struct sfu_epoch_retire_node *next;
+} sfu_epoch_retire_node_t;
+
+typedef struct sfu_epoch_reclaimer {
+  pthread_mutex_t lock;
+  sfu_epoch_retire_node_t *pending;
+  sfu_epoch_retire_node_t *free_nodes;
+  sfu_epoch_generation_fn generation;
+  void *generation_context;
+  uint32_t worker_count;
+  sfu_epoch_retire_node_t nodes[SFU_EPOCH_RECLAIMER_CAPACITY];
+} sfu_epoch_reclaimer_t;
+
+int sfu_epoch_reclaimer_init(sfu_epoch_reclaimer_t *reclaimer, uint32_t worker_count,
+                             sfu_epoch_generation_fn generation, void *generation_context);
+/* Retires ptr using a snapshot of every worker generation. Returns false on
+ * pool exhaustion; ownership remains with the caller and ptr is never freed. */
+bool sfu_epoch_reclaimer_retire(sfu_epoch_reclaimer_t *reclaimer, void *ptr,
+                                sfu_epoch_destructor_fn destructor);
+/* Reclaims records for which every snapshotted worker generation advanced. */
+uint32_t sfu_epoch_reclaimer_sweep(sfu_epoch_reclaimer_t *reclaimer);
+/* Workers must be stopped/quiescent. Drains all records regardless of epochs. */
+void sfu_epoch_reclaimer_destroy_after_quiescence(sfu_epoch_reclaimer_t *reclaimer);
+
+#endif

--- a/src/runtime/fanout.c
+++ b/src/runtime/fanout.c
@@ -1,4 +1,5 @@
 #include "runtime/fanout.h"
+#include "sfu/config.h"
 #include "util/alloc.h"
 #include "util/log.h"
 
@@ -7,6 +8,12 @@
 
 int sfu_fanout_mesh_init(sfu_fanout_mesh_t *mesh, uint32_t worker_count, uint32_t ring_capacity, uint32_t job_pool_capacity) {
   memset(mesh, 0, sizeof(*mesh));
+
+  if (worker_count < 1 || worker_count > SFU_MAX_WORKERS) {
+    SFU_LOG_ERROR("fanout mesh: invalid worker_count %u (must be 1..%d)", worker_count, SFU_MAX_WORKERS);
+    return -1;
+  }
+
   mesh->worker_count = worker_count;
 
   if (sfu_pool_init(&mesh->job_pool, job_pool_capacity, sizeof(sfu_fanout_job_t)) != 0) {

--- a/src/runtime/main.c
+++ b/src/runtime/main.c
@@ -126,6 +126,13 @@ int main(int argc, char **argv) {
   if (worker_count > SFU_MAX_WORKERS) {
     worker_count = SFU_MAX_WORKERS;
   }
+  /* Reject impossible worker counts before any io_uring/fanout/scheduler init.
+   * Auto-detect always yields >= 1 and is clamped to SFU_MAX_WORKERS above;
+   * this guard covers future config overrides and defensive invariants. */
+  if (worker_count < 1 || worker_count > SFU_MAX_WORKERS) {
+    SFU_LOG_ERROR("invalid worker_count %u (must be 1..%d)", worker_count, SFU_MAX_WORKERS);
+    goto cleanup;
+  }
   SFU_LOG_INFO("detected %d online cpus: 1 dispatcher + %u workers", online, worker_count);
   workers = SFU_CALLOC(worker_count, sizeof(*workers));
   scheduler = SFU_CALLOC(1, sizeof(*scheduler));

--- a/src/runtime/scheduler.c
+++ b/src/runtime/scheduler.c
@@ -19,6 +19,11 @@
 
 #define SFU_PENDING_FREE_SWEEP_INTERVAL_SEC 1
 
+static uint64_t scheduler_worker_generation(void *context, uint32_t worker_index) {
+  sfu_worker_t *workers = context;
+  return __atomic_load_n(&workers[worker_index].generation, __ATOMIC_ACQUIRE);
+}
+
 int sfu_scheduler_init(sfu_scheduler_t *s, int core_id, int fd, sfu_packet_pool_t *pp, sfu_worker_t *workers, uint32_t worker_count, int recv_bgid,
                        uint32_t buf_count, uint32_t buf_size) {
   memset(s, 0, sizeof(*s));
@@ -33,9 +38,7 @@ int sfu_scheduler_init(sfu_scheduler_t *s, int core_id, int fd, sfu_packet_pool_
     return -1;
   }
 
-  s->pending_free_head = NULL;
-  if (pthread_mutex_init(&s->pending_free_lock, NULL) != 0) {
-    SFU_LOG_ERROR("scheduler: failed to init pending_free_lock");
+  if (sfu_epoch_reclaimer_init(&s->reclaimer, worker_count, scheduler_worker_generation, workers) != 0) {
     sfu_ring_destroy(&s->recv_ring);
     return -1;
   }
@@ -44,97 +47,21 @@ int sfu_scheduler_init(sfu_scheduler_t *s, int core_id, int fd, sfu_packet_pool_
   return 0;
 }
 
+static void scheduler_free(void *ptr) { SFU_FREE(ptr); }
+
 void sfu_scheduler_destroy(sfu_scheduler_t *s) {
   sfu_ring_destroy(&s->recv_ring);
-
-  sfu_deferred_free_t *df = s->pending_free_head;
-  while (df) {
-    sfu_deferred_free_t *next = df->next;
-    SFU_FREE(df->ptr);
-    SFU_FREE(df->worker_generations);
-    SFU_FREE(df);
-    df = next;
-  }
-  s->pending_free_head = NULL;
-  pthread_mutex_destroy(&s->pending_free_lock);
+  /* Main joins workers before this call. No timeout can make reclamation safe;
+   * shutdown drainage relies exclusively on that quiescence invariant. */
+  sfu_epoch_reclaimer_destroy_after_quiescence(&s->reclaimer);
 }
 
-static void sfu_scheduler_sync_reclaim(sfu_scheduler_t *s, void *ptr) {
-  uint64_t fallback_generations[SFU_MAX_WORKERS];
-  for (uint32_t i = 0; i < s->worker_count && i < SFU_MAX_WORKERS; i++) {
-    fallback_generations[i] = __atomic_load_n(&s->workers[i].generation, __ATOMIC_ACQUIRE);
+bool sfu_scheduler_retire_ptr(sfu_scheduler_t *s, void *ptr) {
+  bool retired = sfu_epoch_reclaimer_retire(&s->reclaimer, ptr, scheduler_free);
+  if (!retired) {
+    SFU_LOG_ERROR("scheduler: retire pool exhausted; caller retains ptr=%p", ptr);
   }
-  for (uint32_t i = 0; i < s->worker_count && i < SFU_MAX_WORKERS; i++) {
-    uint32_t attempts = 0;
-    while (__atomic_load_n(&s->workers[i].generation, __ATOMIC_ACQUIRE) == fallback_generations[i]) {
-      usleep(100);
-      if (++attempts >= 10000) {
-        SFU_LOG_ERROR("scheduler: worker %u generation wait timeout during synchronous reclaim", i);
-        break;
-      }
-    }
-  }
-  SFU_FREE(ptr);
-}
-
-void sfu_scheduler_retire_ptr(sfu_scheduler_t *s, void *ptr) {
-  sfu_deferred_free_t *df = SFU_CALLOC(1, sizeof(*df));
-  if (!df) {
-    SFU_LOG_WARN("scheduler: deferred-free allocation failed; reclaiming synchronously");
-    sfu_scheduler_sync_reclaim(s, ptr);
-    return;
-  }
-
-  df->ptr = ptr;
-  df->worker_count = s->worker_count;
-  df->worker_generations = SFU_CALLOC(s->worker_count, sizeof(uint64_t));
-  if (!df->worker_generations) {
-    SFU_LOG_WARN("scheduler: generation snapshot allocation failed; reclaiming synchronously");
-    SFU_FREE(df);
-    sfu_scheduler_sync_reclaim(s, ptr);
-    return;
-  }
-  for (uint32_t i = 0; i < s->worker_count; i++) {
-    df->worker_generations[i] = __atomic_load_n(&s->workers[i].generation, __ATOMIC_ACQUIRE);
-  }
-
-  pthread_mutex_lock(&s->pending_free_lock);
-  df->next = s->pending_free_head;
-  s->pending_free_head = df;
-  pthread_mutex_unlock(&s->pending_free_lock);
-}
-
-static void sweep_pending_frees(sfu_scheduler_t *s) {
-  if (!s->pending_free_head) {
-    return;
-  }
-
-  pthread_mutex_lock(&s->pending_free_lock);
-
-  sfu_deferred_free_t **cursor = &s->pending_free_head;
-  while (*cursor) {
-    sfu_deferred_free_t *df = *cursor;
-
-    bool safe = true;
-    for (uint32_t i = 0; i < df->worker_count; i++) {
-      uint64_t current = __atomic_load_n(&s->workers[i].generation, __ATOMIC_ACQUIRE);
-      if (current == df->worker_generations[i]) {
-        safe = false;
-        break;
-      }
-    }
-
-    if (safe) {
-      *cursor = df->next;
-      SFU_FREE(df->ptr);
-      SFU_FREE(df->worker_generations);
-      SFU_FREE(df);
-    } else {
-      cursor = &df->next;
-    }
-  }
-
-  pthread_mutex_unlock(&s->pending_free_lock);
+  return retired;
 }
 
 typedef struct {
@@ -143,6 +70,14 @@ typedef struct {
 
 static void on_recv(void *user_data, sfu_packet_t *pkt) {
   sfu_scheduler_t *s = ((recv_ctx_t *)user_data)->s;
+
+  /* Defensive: h % 0 is SIGFPE. Startup must reject worker_count == 0;
+   * if we still land here, drop safely. */
+  if (SFU_UNLIKELY(s->worker_count == 0)) {
+    SFU_LOG_ERROR("scheduler: worker_count is 0; dropping packet (misconfiguration)");
+    sfu_ring_release_packet(&s->recv_ring, s->pp, pkt);
+    return;
+  }
 
   uint32_t h = fnv1a(&pkt->peer_addr, pkt->peer_addr_len);
   uint32_t worker_idx = h % s->worker_count;
@@ -178,7 +113,7 @@ static void *scheduler_thread_main(void *arg) {
     struct timespec now;
     clock_gettime(CLOCK_MONOTONIC, &now);
     if (now.tv_sec - s->last_sweep.tv_sec >= SFU_PENDING_FREE_SWEEP_INTERVAL_SEC) {
-      sweep_pending_frees(s);
+      sfu_epoch_reclaimer_sweep(&s->reclaimer);
       s->last_sweep = now;
     }
 

--- a/src/runtime/scheduler.h
+++ b/src/runtime/scheduler.h
@@ -7,6 +7,7 @@
 #include "media/svc/vp9_parser.h"
 #include "memory/packet_pool.h"
 #include "net/io_uring.h"
+#include "runtime/epoch_reclaimer.h"
 
 typedef struct sfu_worker sfu_worker_t;
 
@@ -20,20 +21,12 @@ typedef struct sfu_subscriber_scheduler {
   bool needs_keyframe;
 } sfu_subscriber_scheduler_t;
 
-typedef struct sfu_deferred_free {
-  void *ptr;
-  uint64_t *worker_generations;
-  struct sfu_deferred_free *next;
-  uint32_t worker_count;
-} sfu_deferred_free_t;
-
 typedef struct sfu_scheduler {
   sfu_ring_t recv_ring;
-  pthread_mutex_t pending_free_lock;
+  sfu_epoch_reclaimer_t reclaimer;
   struct timespec last_sweep;
   sfu_packet_pool_t *pp;
   sfu_worker_t *workers;
-  sfu_deferred_free_t *pending_free_head;
   pthread_t thread;
   uint32_t worker_count;
   int core_id;
@@ -45,7 +38,8 @@ int sfu_scheduler_init(sfu_scheduler_t *s, int core_id, int fd, sfu_packet_pool_
 void sfu_scheduler_destroy(sfu_scheduler_t *s);
 int sfu_scheduler_start(sfu_scheduler_t *s);
 void sfu_scheduler_join(sfu_scheduler_t *s);
-void sfu_scheduler_retire_ptr(sfu_scheduler_t *s, void *ptr);
+/* Returns false without freeing ptr; ownership then remains with the caller. */
+bool sfu_scheduler_retire_ptr(sfu_scheduler_t *s, void *ptr);
 void sfu_subscriber_scheduler_init(sfu_subscriber_scheduler_t *sched, uint32_t initial_publisher);
 bool sfu_scheduler_evaluate_frame(sfu_subscriber_scheduler_t *sched, const sfu_vp9_descriptor_t *desc, bool is_keyframe);
 

--- a/src/runtime/worker.c
+++ b/src/runtime/worker.c
@@ -15,6 +15,7 @@
 #include "runtime/timer.h"
 #include "transport/srtp/srtp.h"
 #include "util/log.h"
+#include "util/netbytes.h"
 
 #define SFU_WORKER_SEND_SQ_ENTRIES 1024
 #define SFU_WORKER_SEND_CQ_ENTRIES 2048
@@ -175,8 +176,19 @@ void sfu_room_forward_packet(sfu_worker_t *w, sfu_packet_t *pkt) {
         uint8_t rtx_pt = 0;
 
         if (sfu_rtx_cache_get(sender_session->rtx_cache, lost_seq, orig_pkt, &orig_len, &rtx_ssrc, &rtx_pt)) {
+          // Fixed 12-byte RTP header for now; variable-header RTX is a later PR.
+          if (orig_len < 12) {
+            continue;
+          }
+
           sfu_packet_t *rtx_enc = sfu_packet_pool_alloc(w->pp);
           if (!rtx_enc) {
+            continue;
+          }
+
+          int total = (int)orig_len + 2;
+          if (total > (int)rtx_enc->cap) {
+            sfu_worker_release_packet(w->pp, &w->release_to_dispatcher, rtx_enc);
             continue;
           }
 
@@ -186,13 +198,13 @@ void sfu_room_forward_packet(sfu_worker_t *w, sfu_packet_t *pkt) {
           rtx_enc->data[1] = (rtx_enc->data[1] & 0x80) | (rtx_pt & 0x7F);
 
           uint16_t next_rtx_seq = __atomic_fetch_add(&sender_session->rtx_cache->next_rtx_seq, 1, __ATOMIC_RELAXED);
-          *(uint16_t *)(rtx_enc->data + 2) = htons(next_rtx_seq);
-          *(uint32_t *)(rtx_enc->data + 8) = htonl(rtx_ssrc);
+          sfu_write_be16(rtx_enc->data + 2, next_rtx_seq);
+          sfu_write_be32(rtx_enc->data + 8, rtx_ssrc);
 
-          *(uint16_t *)(rtx_enc->data + rtp_header_len) = htons(lost_seq);
-          memcpy(rtx_enc->data + rtp_header_len + 2, orig_pkt + rtp_header_len, orig_len - rtp_header_len);
+          sfu_write_be16(rtx_enc->data + rtp_header_len, lost_seq);
+          memcpy(rtx_enc->data + rtp_header_len + 2, orig_pkt + rtp_header_len, orig_len - (uint32_t)rtp_header_len);
 
-          int rtx_enc_len = orig_len + 2;
+          int rtx_enc_len = total;
           if (sfu_srtp_protect_rtp(&sender_session->srtp, rtx_enc->data, &rtx_enc_len, rtx_enc->cap)) {
             rtx_enc->len = (uint32_t)rtx_enc_len;
             sfu_ring_queue_send_zc(&w->send_ring, rtx_enc, (const struct sockaddr *)&sender_session->cold->addr, sender_session->cold->addr_len);
@@ -289,7 +301,7 @@ void sfu_room_forward_packet(sfu_worker_t *w, sfu_packet_t *pkt) {
         enc->data[1] = (enc->data[1] & 0x80) | (expected_pt & 0x7F);
       }
 
-      uint16_t subscriber_seq = ntohs(*(uint16_t *)(enc->data + 2));
+      uint16_t subscriber_seq = sfu_read_be16(enc->data + 2);
       if (slot->video && incoming_pt == slot->video->payload_type) {
         sfu_rtx_cache_put(sub_session->rtx_cache, subscriber_seq, enc->data, enc_len, slot->video->rtx_ssrc, slot->video->rtx_payload_type);
       }

--- a/src/util/metrics.c
+++ b/src/util/metrics.c
@@ -1,0 +1,84 @@
+#include "util/metrics.h"
+
+#include <stdatomic.h>
+#include <stdio.h>
+#include <string.h>
+
+/*
+ * Built-in counters. Keep the table small and static: hot-path sites will
+ * call sfu_metric_inc() by string name. Linear scan is fine at this scale;
+ * switch to enum indices only if profiling shows lookup cost.
+ *
+ * Names here are stable ABI for snapshot consumers — do not rename lightly.
+ */
+static const char *const k_metric_names[] = {
+    "msg_trunc_drop",
+    "json_reject",
+};
+
+enum { SFU_METRIC_COUNT = sizeof(k_metric_names) / sizeof(k_metric_names[0]) };
+
+static _Atomic uint64_t g_counters[SFU_METRIC_COUNT];
+
+static int find_metric(const char *name) {
+  if (!name) {
+    return -1;
+  }
+  for (int i = 0; i < SFU_METRIC_COUNT; i++) {
+    if (strcmp(k_metric_names[i], name) == 0) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+void sfu_metrics_init(void) {
+  for (int i = 0; i < SFU_METRIC_COUNT; i++) {
+    atomic_store_explicit(&g_counters[i], 0, memory_order_relaxed);
+  }
+}
+
+void sfu_metric_inc(const char *name) {
+  int idx = find_metric(name);
+  if (idx < 0) {
+    return;
+  }
+  atomic_fetch_add_explicit(&g_counters[idx], 1, memory_order_relaxed);
+}
+
+uint64_t sfu_metric_get(const char *name) {
+  int idx = find_metric(name);
+  if (idx < 0) {
+    return 0;
+  }
+  return atomic_load_explicit(&g_counters[idx], memory_order_relaxed);
+}
+
+size_t sfu_metrics_snapshot(char *buf, size_t cap) {
+  size_t needed = 0;
+  size_t used = 0;
+
+  if (buf && cap > 0) {
+    buf[0] = '\0';
+  }
+
+  for (int i = 0; i < SFU_METRIC_COUNT; i++) {
+    uint64_t v = atomic_load_explicit(&g_counters[i], memory_order_relaxed);
+    char line[128];
+    int n = snprintf(line, sizeof(line), "%s %llu\n", k_metric_names[i], (unsigned long long)v);
+    if (n < 0) {
+      continue;
+    }
+    needed += (size_t)n;
+
+    if (buf && cap > 0 && used + 1 < cap) {
+      size_t space = cap - 1 - used; /* leave room for NUL */
+      size_t copy = (size_t)n < space ? (size_t)n : space;
+      memcpy(buf + used, line, copy);
+      used += copy;
+      buf[used] = '\0';
+    }
+  }
+
+  return needed;
+}

--- a/src/util/metrics.h
+++ b/src/util/metrics.h
@@ -1,0 +1,35 @@
+#ifndef SFU_UTIL_METRICS_H
+#define SFU_UTIL_METRICS_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+/*
+ * Minimal dependency-free metrics registry.
+ *
+ * Fixed table of named counters, zeroed at sfu_metrics_init(). Counters are
+ * registered at compile time (see metrics.c); later PRs instrument call sites
+ * by name. No dynamic registration, no external deps.
+ *
+ * Thread-safety: increments use memory_order_relaxed atomics. Snapshot is
+ * best-effort — values for different counters may tear relative to each
+ * other; that is acceptable for ops dashboards and tests.
+ */
+
+void sfu_metrics_init(void);
+
+/* Increment named counter by 1. No-op if name is NULL or unknown. */
+void sfu_metric_inc(const char *name);
+
+/* Read current value. Returns 0 if name is NULL or unknown. */
+uint64_t sfu_metric_get(const char *name);
+
+/*
+ * Render "name value" lines (one per counter, trailing newline each) into
+ * buf. Always NUL-terminates when cap > 0. Returns the number of bytes that
+ * would have been written excluding the NUL (snprintf-style); if the return
+ * value is >= cap the output was truncated.
+ */
+size_t sfu_metrics_snapshot(char *buf, size_t cap);
+
+#endif /* SFU_UTIL_METRICS_H */

--- a/src/util/netbytes.h
+++ b/src/util/netbytes.h
@@ -1,0 +1,37 @@
+#ifndef SFU_UTIL_NETBYTES_H
+#define SFU_UTIL_NETBYTES_H
+
+#include <stdint.h>
+
+/*
+ * Alignment- and endian-safe big-endian integer load/store helpers.
+ * Byte-assembly only — no unaligned multi-byte casts, no host ntohs/htonl.
+ * Use these for protocol parsers that walk packet buffers at arbitrary offsets.
+ */
+
+static inline uint16_t sfu_read_be16(const uint8_t *p) {
+  return (uint16_t)(((uint16_t)p[0] << 8) | (uint16_t)p[1]);
+}
+
+static inline uint32_t sfu_read_be24(const uint8_t *p) {
+  return ((uint32_t)p[0] << 16) | ((uint32_t)p[1] << 8) | (uint32_t)p[2];
+}
+
+static inline uint32_t sfu_read_be32(const uint8_t *p) {
+  return ((uint32_t)p[0] << 24) | ((uint32_t)p[1] << 16) | ((uint32_t)p[2] << 8) |
+         (uint32_t)p[3];
+}
+
+static inline void sfu_write_be16(uint8_t *p, uint16_t v) {
+  p[0] = (uint8_t)(v >> 8);
+  p[1] = (uint8_t)(v);
+}
+
+static inline void sfu_write_be32(uint8_t *p, uint32_t v) {
+  p[0] = (uint8_t)(v >> 24);
+  p[1] = (uint8_t)(v >> 16);
+  p[2] = (uint8_t)(v >> 8);
+  p[3] = (uint8_t)(v);
+}
+
+#endif /* SFU_UTIL_NETBYTES_H */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,3 +46,39 @@ add_executable(test_session_table test_session_table.c)
 target_link_libraries(test_session_table PRIVATE sfu_core)
 add_test(NAME session_table COMMAND test_session_table)
 
+add_executable(test_netbytes test_netbytes.c)
+target_link_libraries(test_netbytes PRIVATE sfu_core)
+add_test(NAME netbytes COMMAND test_netbytes)
+
+add_executable(test_metrics test_metrics.c)
+target_link_libraries(test_metrics PRIVATE sfu_core)
+add_test(NAME metrics COMMAND test_metrics)
+
+add_executable(test_rtx_capacity test_rtx_capacity.c)
+target_link_libraries(test_rtx_capacity PRIVATE sfu_core)
+add_test(NAME rtx_capacity COMMAND test_rtx_capacity)
+
+add_executable(test_epoch_reclaimer test_epoch_reclaimer.c)
+target_link_libraries(test_epoch_reclaimer PRIVATE sfu_core)
+add_test(NAME epoch_reclaimer COMMAND test_epoch_reclaimer)
+
+add_executable(test_rtcp_compound test_rtcp_compound.c)
+target_link_libraries(test_rtcp_compound PRIVATE sfu_core)
+add_test(NAME rtcp_compound COMMAND test_rtcp_compound)
+
+add_executable(test_rtp_packet test_rtp_packet.c)
+target_link_libraries(test_rtp_packet PRIVATE sfu_core)
+add_test(NAME rtp_packet COMMAND test_rtp_packet)
+
+add_executable(test_rtcp_fb test_rtcp_fb.c)
+target_link_libraries(test_rtcp_fb PRIVATE sfu_core)
+add_test(NAME rtcp_fb COMMAND test_rtcp_fb)
+
+add_executable(test_valkey_queue test_valkey_queue.c)
+target_link_libraries(test_valkey_queue PRIVATE sfu_core)
+add_test(NAME valkey_queue COMMAND test_valkey_queue)
+
+add_executable(test_rtx_build test_rtx_build.c)
+target_link_libraries(test_rtx_build PRIVATE sfu_core)
+add_test(NAME rtx_build COMMAND test_rtx_build)
+

--- a/tests/test_epoch_reclaimer.c
+++ b/tests/test_epoch_reclaimer.c
@@ -1,0 +1,81 @@
+#include <assert.h>
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include "runtime/epoch_reclaimer.h"
+
+typedef struct { _Atomic uint64_t generations[2]; } epochs_t;
+static _Atomic uint32_t destroyed;
+
+static uint64_t generation(void *ctx, uint32_t i) {
+  epochs_t *epochs = ctx;
+  return atomic_load(&epochs->generations[i]);
+}
+static void destroy(void *ptr) { atomic_fetch_add(&destroyed, 1); free(ptr); }
+
+typedef struct {
+  sfu_epoch_reclaimer_t *r;
+  epochs_t *epochs;
+} concurrent_ctx_t;
+static void *retire_loop(void *arg) {
+  concurrent_ctx_t *ctx = arg;
+  for (uint32_t i = 0; i < 50000; i++) {
+    void *ptr = malloc(1);
+    while (!sfu_epoch_reclaimer_retire(ctx->r, ptr, destroy)) {
+      sfu_epoch_reclaimer_sweep(ctx->r);
+    }
+    atomic_fetch_add(&ctx->epochs->generations[0], 1);
+    atomic_fetch_add(&ctx->epochs->generations[1], 1);
+  }
+  return NULL;
+}
+static void *sweep_loop(void *arg) {
+  concurrent_ctx_t *ctx = arg;
+  for (uint32_t i = 0; i < 50000; i++) {
+    sfu_epoch_reclaimer_sweep(ctx->r);
+  }
+  return NULL;
+}
+
+int main(void) {
+  epochs_t epochs = {0};
+  sfu_epoch_reclaimer_t r;
+  assert(sfu_epoch_reclaimer_init(&r, 2, generation, &epochs) == 0);
+
+  assert(sfu_epoch_reclaimer_retire(&r, malloc(1), destroy));
+  atomic_fetch_add(&epochs.generations[0], 1);
+  assert(sfu_epoch_reclaimer_sweep(&r) == 0); /* worker 1 is stalled */
+  assert(atomic_load(&destroyed) == 0);
+  atomic_fetch_add(&epochs.generations[1], 1);
+  assert(sfu_epoch_reclaimer_sweep(&r) == 1);
+  assert(atomic_load(&destroyed) == 1); /* exactly once */
+  assert(sfu_epoch_reclaimer_sweep(&r) == 0);
+
+  void *retained = NULL;
+  for (uint32_t i = 0; i < SFU_EPOCH_RECLAIMER_CAPACITY; i++)
+    assert(sfu_epoch_reclaimer_retire(&r, malloc(1), destroy));
+  retained = malloc(1);
+  assert(!sfu_epoch_reclaimer_retire(&r, retained, destroy));
+  assert(atomic_load(&destroyed) == 1); /* exhaustion never destroys */
+  free(retained); /* caller retained ownership */
+  sfu_epoch_reclaimer_destroy_after_quiescence(&r);
+  assert(atomic_load(&destroyed) == 1 + SFU_EPOCH_RECLAIMER_CAPACITY);
+
+  /* Concurrent retire/sweep smoke: no leaks or double-destruction under
+   * quiescent final drain. */
+  atomic_store(&destroyed, 0);
+  assert(sfu_epoch_reclaimer_init(&r, 2, generation, &epochs) == 0);
+  concurrent_ctx_t ctx = {.r = &r, .epochs = &epochs};
+  pthread_t retire_thread, sweep_thread;
+  assert(pthread_create(&retire_thread, NULL, retire_loop, &ctx) == 0);
+  assert(pthread_create(&sweep_thread, NULL, sweep_loop, &ctx) == 0);
+  assert(pthread_join(retire_thread, NULL) == 0);
+  assert(pthread_join(sweep_thread, NULL) == 0);
+  sfu_epoch_reclaimer_destroy_after_quiescence(&r);
+  assert(atomic_load(&destroyed) == 50000); /* every retired ptr freed once */
+
+  printf("test_epoch_reclaimer: OK\n");
+  return 0;
+}

--- a/tests/test_json_lite.c
+++ b/tests/test_json_lite.c
@@ -70,6 +70,43 @@ int main(void) {
     assert(sfu_json_extract_string(json, 10, "sdp", out, sizeof(out)) == -1);
   }
 
+  /* Empty-string field with out_cap=0 must reject before any write. */
+  {
+    unsigned char canary = 0xA5;
+    int n = sfu_json_extract_string("{\"sdp\":\"\"}", strlen("{\"sdp\":\"\"}"), "sdp", (char *)&canary, 0);
+    assert(n == -1);
+    assert(canary == 0xA5);
+  }
+
+  /* out_cap=1 with empty string succeeds with just the trailing NUL. */
+  {
+    char out = 0x5A;
+    int n = sfu_json_extract_string("{\"sdp\":\"\"}", strlen("{\"sdp\":\"\"}"), "sdp", &out, 1);
+    assert(n == 0);
+    assert(out == '\0');
+  }
+
+  /* Normal extraction of a non-empty string field. */
+  {
+    char out[16];
+    int n = sfu_json_extract_string("{\"room\":\"abc\"}", strlen("{\"room\":\"abc\"}"), "room", out, sizeof(out));
+    assert(n == 3);
+    assert(strcmp(out, "abc") == 0);
+  }
+
+  /* Escape with out == NULL must return -1 without writing. */
+  {
+    assert(sfu_json_escape("x", 1, NULL, 8) == -1);
+    assert(sfu_json_escape("", 0, NULL, 1) == -1);
+  }
+
+  /* Escape with out_cap == 0 must return -1 and leave the canary untouched. */
+  {
+    unsigned char canary = 0xA5;
+    assert(sfu_json_escape("", 0, (char *)&canary, 0) == -1);
+    assert(canary == 0xA5);
+  }
+
   printf("test_json_lite: OK\n");
   return 0;
 }

--- a/tests/test_metrics.c
+++ b/tests/test_metrics.c
@@ -1,0 +1,113 @@
+#include "util/metrics.h"
+
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define THREADS 4
+#define INCS_PER_THREAD 10000
+#define COUNTER_NAME "msg_trunc_drop"
+
+#define EXPECT(cond)                                                     \
+  do {                                                                   \
+    if (!(cond)) {                                                       \
+      fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond);    \
+      exit(1);                                                           \
+    }                                                                    \
+  } while (0)
+
+static void *inc_worker(void *arg) {
+  (void)arg;
+  for (int i = 0; i < INCS_PER_THREAD; i++) {
+    sfu_metric_inc(COUNTER_NAME);
+  }
+  return NULL;
+}
+
+static void test_init_and_get(void) {
+  sfu_metrics_init();
+  EXPECT(sfu_metric_get("msg_trunc_drop") == 0);
+  EXPECT(sfu_metric_get("json_reject") == 0);
+  EXPECT(sfu_metric_get("unknown_metric") == 0);
+  EXPECT(sfu_metric_get(NULL) == 0);
+}
+
+static void test_inc_get(void) {
+  sfu_metrics_init();
+
+  sfu_metric_inc("msg_trunc_drop");
+  sfu_metric_inc("msg_trunc_drop");
+  sfu_metric_inc("json_reject");
+  sfu_metric_inc("not_a_real_counter"); /* no-op */
+  sfu_metric_inc(NULL);                  /* no-op */
+
+  EXPECT(sfu_metric_get("msg_trunc_drop") == 2);
+  EXPECT(sfu_metric_get("json_reject") == 1);
+  EXPECT(sfu_metric_get("not_a_real_counter") == 0);
+}
+
+static void test_snapshot_format(void) {
+  sfu_metrics_init();
+  sfu_metric_inc("json_reject");
+  sfu_metric_inc("json_reject");
+  sfu_metric_inc("json_reject");
+
+  char buf[256];
+  size_t n = sfu_metrics_snapshot(buf, sizeof(buf));
+  EXPECT(n > 0);
+  EXPECT(n < sizeof(buf)); /* fits */
+  EXPECT(strlen(buf) == n);
+
+  /* Expect one "name value\n" line per registered counter, in table order. */
+  EXPECT(strstr(buf, "msg_trunc_drop 0\n") != NULL);
+  EXPECT(strstr(buf, "json_reject 3\n") != NULL);
+
+  /* Every line is "name value" with a single space and trailing newline. */
+  const char *p = buf;
+  int lines = 0;
+  while (*p) {
+    const char *nl = strchr(p, '\n');
+    EXPECT(nl != NULL);
+    const char *sp = strchr(p, ' ');
+    EXPECT(sp != NULL && sp < nl);
+    /* no second space before newline */
+    EXPECT(memchr(sp + 1, ' ', (size_t)(nl - sp - 1)) == NULL);
+    p = nl + 1;
+    lines++;
+  }
+  EXPECT(lines == 2);
+
+  /* Truncation: tiny buffer still NUL-terminated; return is full length. */
+  char tiny[8];
+  size_t full = sfu_metrics_snapshot(tiny, sizeof(tiny));
+  EXPECT(full == n);
+  EXPECT(strlen(tiny) < sizeof(tiny));
+  EXPECT(tiny[0] != '\0');
+}
+
+static void test_multithreaded_inc(void) {
+  sfu_metrics_init();
+
+  pthread_t threads[THREADS];
+  for (int i = 0; i < THREADS; i++) {
+    EXPECT(pthread_create(&threads[i], NULL, inc_worker, NULL) == 0);
+  }
+  for (int i = 0; i < THREADS; i++) {
+    EXPECT(pthread_join(threads[i], NULL) == 0);
+  }
+
+  uint64_t total = sfu_metric_get(COUNTER_NAME);
+  EXPECT(total == (uint64_t)THREADS * INCS_PER_THREAD);
+  EXPECT(sfu_metric_get("json_reject") == 0);
+}
+
+int main(void) {
+  test_init_and_get();
+  test_inc_get();
+  test_snapshot_format();
+  test_multithreaded_inc();
+
+  printf("test_metrics: OK\n");
+  return 0;
+}

--- a/tests/test_netbytes.c
+++ b/tests/test_netbytes.c
@@ -1,0 +1,74 @@
+#include "util/netbytes.h"
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void test_aligned_roundtrip(void) {
+  uint8_t buf[8];
+
+  sfu_write_be16(buf, 0x1234);
+  assert(buf[0] == 0x12 && buf[1] == 0x34);
+  assert(sfu_read_be16(buf) == 0x1234);
+
+  sfu_write_be32(buf, 0x89ABCDEF);
+  assert(buf[0] == 0x89 && buf[1] == 0xAB && buf[2] == 0xCD && buf[3] == 0xEF);
+  assert(sfu_read_be32(buf) == 0x89ABCDEFu);
+
+  /* be24 via explicit bytes (no write helper) */
+  buf[0] = 0x01;
+  buf[1] = 0x02;
+  buf[2] = 0x03;
+  assert(sfu_read_be24(buf) == 0x00010203u);
+
+  /* edge values */
+  sfu_write_be16(buf, 0);
+  assert(sfu_read_be16(buf) == 0);
+  sfu_write_be16(buf, 0xFFFF);
+  assert(sfu_read_be16(buf) == 0xFFFF);
+
+  sfu_write_be32(buf, 0);
+  assert(sfu_read_be32(buf) == 0);
+  sfu_write_be32(buf, 0xFFFFFFFFu);
+  assert(sfu_read_be32(buf) == 0xFFFFFFFFu);
+
+  buf[0] = 0xFF;
+  buf[1] = 0xFF;
+  buf[2] = 0xFF;
+  assert(sfu_read_be24(buf) == 0x00FFFFFFu);
+}
+
+static void test_unaligned_reads(void) {
+  /* malloc+1 forces odd (typically unaligned) pointer */
+  uint8_t *raw = (uint8_t *)malloc(16);
+  assert(raw != NULL);
+  uint8_t *p = raw + 1;
+
+  memset(raw, 0xCC, 16);
+
+  sfu_write_be16(p, 0xA1B2);
+  assert(sfu_read_be16(p) == 0xA1B2);
+
+  sfu_write_be32(p + 2, 0x11223344u);
+  assert(sfu_read_be32(p + 2) == 0x11223344u);
+
+  p[6] = 0x0A;
+  p[7] = 0x0B;
+  p[8] = 0x0C;
+  assert(sfu_read_be24(p + 6) == 0x000A0B0Cu);
+
+  /* signed-style large-delta pattern used by TWCC (int16 via be16) */
+  sfu_write_be16(p, (uint16_t)(int16_t)-4);
+  assert((int16_t)sfu_read_be16(p) == -4);
+
+  free(raw);
+}
+
+int main(void) {
+  test_aligned_roundtrip();
+  test_unaligned_reads();
+  printf("test_netbytes: OK\n");
+  return 0;
+}

--- a/tests/test_rtcp_compound.c
+++ b/tests/test_rtcp_compound.c
@@ -1,0 +1,122 @@
+#include "rtcp/rtcp_compound.h"
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+static sfu_rtcp_member_view next_item(sfu_rtcp_compound_iter *it) {
+  sfu_rtcp_member_view view;
+  assert(sfu_rtcp_compound_iter_next(it, &view) == SFU_RTCP_COMPOUND_ITEM);
+  return view;
+}
+
+static void test_single_member(void) {
+  const uint8_t rr[] = {0x80, 201, 0, 1, 0x11, 0x22, 0x33, 0x44};
+  sfu_rtcp_compound_iter it;
+  sfu_rtcp_compound_iter_init(&it, rr, sizeof(rr));
+  sfu_rtcp_member_view view = next_item(&it);
+  assert(view.member == rr && view.member_len == sizeof(rr));
+  assert(view.fmt_count == 0 && view.pt == 201);
+  assert(view.sender_ssrc == 0x11223344u);
+  assert(view.body == rr + 8 && view.body_len == 0);
+  assert(sfu_rtcp_compound_iter_next(&it, &view) == SFU_RTCP_COMPOUND_END);
+}
+
+static void test_rr_nack(void) {
+  const uint8_t packet[] = {
+      0x80, 201, 0, 1, 0, 0, 0, 1,
+      0x81, 205, 0, 3, 0, 0, 0, 2, 0, 0, 0, 3, 0x12, 0x34, 0, 1,
+  };
+  sfu_rtcp_compound_iter it;
+  sfu_rtcp_compound_iter_init(&it, packet, sizeof(packet));
+  sfu_rtcp_member_view rr = next_item(&it);
+  sfu_rtcp_member_view nack = next_item(&it);
+  assert(rr.member == packet && rr.member_len == 8);
+  assert(nack.member == packet + 8 && nack.member_len == 16);
+  assert(nack.fmt_count == 1 && nack.pt == 205 && nack.sender_ssrc == 2);
+  assert(nack.body == packet + 16 && nack.body_len == 8);
+  assert(sfu_rtcp_compound_iter_next(&it, &nack) == SFU_RTCP_COMPOUND_END);
+}
+
+static void test_nack_pli_boundaries(void) {
+  const uint8_t packet[] = {
+      0x81, 205, 0, 3, 0, 0, 0, 4, 0, 0, 0, 5, 0xab, 0xcd, 0, 0,
+      0x81, 206, 0, 2, 0, 0, 0, 6, 0, 0, 0, 7,
+  };
+  sfu_rtcp_compound_iter it;
+  sfu_rtcp_compound_iter_init(&it, packet, sizeof(packet));
+  sfu_rtcp_member_view nack = next_item(&it);
+  sfu_rtcp_member_view pli = next_item(&it);
+  assert(nack.member + nack.member_len == pli.member);
+  assert(pli.member == packet + 16 && pli.member_len == 12);
+  assert(pli.fmt_count == 1 && pli.pt == 206 && pli.body_len == 4);
+  assert(sfu_rtcp_compound_iter_next(&it, &pli) == SFU_RTCP_COMPOUND_END);
+}
+
+static void expect_malformed(const uint8_t *packet, size_t len) {
+  sfu_rtcp_compound_iter it;
+  sfu_rtcp_member_view view;
+  sfu_rtcp_compound_iter_init(&it, packet, len);
+  assert(sfu_rtcp_compound_iter_next(&it, &view) == SFU_RTCP_COMPOUND_MALFORMED);
+  assert(sfu_rtcp_compound_iter_next(&it, &view) == SFU_RTCP_COMPOUND_MALFORMED);
+}
+
+static void test_bad_headers_and_lengths(void) {
+  const uint8_t bad_version[] = {0x40, 201, 0, 1, 0, 0, 0, 1};
+  const uint8_t too_long[] = {0x80, 201, 0, 2, 0, 0, 0, 1};
+  const uint8_t too_short[] = {0x80, 201, 0, 0};
+  expect_malformed(bad_version, sizeof(bad_version));
+  expect_malformed(too_long, sizeof(too_long));
+  expect_malformed(too_short, sizeof(too_short));
+}
+
+static void test_trailing_garbage(void) {
+  const uint8_t packet[] = {0x80, 201, 0, 1, 0, 0, 0, 1, 0xaa, 0xbb, 0xcc};
+  sfu_rtcp_compound_iter it;
+  sfu_rtcp_member_view view;
+  sfu_rtcp_compound_iter_init(&it, packet, sizeof(packet));
+  assert(sfu_rtcp_compound_iter_next(&it, &view) == SFU_RTCP_COMPOUND_ITEM);
+  assert(sfu_rtcp_compound_iter_next(&it, &view) == SFU_RTCP_COMPOUND_MALFORMED);
+}
+
+static void test_padding(void) {
+  const uint8_t valid[] = {0xa0, 201, 0, 2, 0, 0, 0, 1, 0, 0, 0, 4};
+  const uint8_t zero[] = {0xa0, 201, 0, 2, 0, 0, 0, 1, 0, 0, 0, 0};
+  const uint8_t excessive[] = {0xa0, 201, 0, 2, 0, 0, 0, 1, 0, 0, 0, 9};
+  sfu_rtcp_compound_iter it;
+  sfu_rtcp_compound_iter_init(&it, valid, sizeof(valid));
+  sfu_rtcp_member_view view = next_item(&it);
+  assert(view.member_len == 8 && view.body_len == 0);
+  assert(sfu_rtcp_compound_iter_next(&it, &view) == SFU_RTCP_COMPOUND_END);
+  expect_malformed(zero, sizeof(zero));
+  expect_malformed(excessive, sizeof(excessive));
+}
+
+static void test_max_length_no_overflow(void) {
+  const uint8_t packet[] = {0x80, 201, 0xff, 0xff, 0, 0, 0, 1};
+  expect_malformed(packet, sizeof(packet));
+}
+
+static void test_unaligned_buffer(void) {
+  uint8_t storage[9];
+  const uint8_t packet[] = {0x80, 201, 0, 1, 0xde, 0xad, 0xbe, 0xef};
+  memcpy(storage + 1, packet, sizeof(packet));
+  sfu_rtcp_compound_iter it;
+  sfu_rtcp_compound_iter_init(&it, storage + 1, sizeof(packet));
+  sfu_rtcp_member_view view = next_item(&it);
+  assert(view.member == storage + 1 && view.sender_ssrc == 0xdeadbeefu);
+}
+
+int main(void) {
+  test_single_member();
+  test_rr_nack();
+  test_nack_pli_boundaries();
+  test_bad_headers_and_lengths();
+  test_trailing_garbage();
+  test_padding();
+  test_max_length_no_overflow();
+  test_unaligned_buffer();
+  puts("rtcp compound tests passed");
+  return 0;
+}

--- a/tests/test_rtcp_fb.c
+++ b/tests/test_rtcp_fb.c
@@ -1,0 +1,85 @@
+#include "rtcp/rtcp_fb.h"
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+static sfu_rtcp_member_view view_of(const uint8_t *packet, size_t len) {
+  sfu_rtcp_compound_iter iter;
+  sfu_rtcp_member_view view;
+  sfu_rtcp_compound_iter_init(&iter, packet, len);
+  assert(sfu_rtcp_compound_iter_next(&iter, &view) == SFU_RTCP_COMPOUND_ITEM);
+  return view;
+}
+
+static void test_pli(void) {
+  const uint8_t packet[] = {0x81, 206, 0, 2, 0x11, 0x22, 0x33, 0x44,
+                            0xaa, 0xbb, 0xcc, 0xdd};
+  sfu_rtcp_member_view view = view_of(packet, sizeof(packet));
+  sfu_rtcp_pli pli;
+  assert(sfu_rtcp_parse_pli(&view, &pli));
+  assert(pli.sender_ssrc == 0x11223344u && pli.media_ssrc == 0xaabbccddu);
+
+  sfu_rtcp_member_view bad = view;
+  bad.pt = 205; assert(!sfu_rtcp_parse_pli(&bad, &pli));
+  bad = view; bad.fmt_count = 2; assert(!sfu_rtcp_parse_pli(&bad, &pli));
+  bad = view; bad.member_len = 16; assert(!sfu_rtcp_parse_pli(&bad, &pli));
+  bad = view; bad.body_len = 8; assert(!sfu_rtcp_parse_pli(&bad, &pli));
+}
+
+static void test_padding_logical_pli(void) {
+  const uint8_t padded[] = {0xa1, 206, 0, 3, 0, 0, 0, 1,
+                            0, 0, 0, 2, 0, 0, 0, 4};
+  sfu_rtcp_member_view view = view_of(padded, sizeof(padded));
+  sfu_rtcp_pli pli;
+  assert(view.member_len == 12 && view.body_len == 4);
+  assert(sfu_rtcp_parse_pli(&view, &pli) && pli.media_ssrc == 2);
+}
+
+static void test_fir(void) {
+  const uint8_t packet[] = {
+      0x84, 206, 0, 4, 0x11, 0x22, 0x33, 0x44, 0, 0, 0, 0,
+      0xaa, 0xbb, 0xcc, 0xdd, 7, 0, 0, 0,
+  };
+  sfu_rtcp_member_view view = view_of(packet, sizeof(packet));
+  sfu_rtcp_fir fir;
+  sfu_rtcp_fir_entry entry;
+  assert(sfu_rtcp_parse_fir(&view, &fir));
+  assert(fir.sender_ssrc == 0x11223344u && fir.media_ssrc == 0 && fir.entry_count == 1);
+  assert(sfu_rtcp_fir_entry_at(&fir, 0, &entry));
+  assert(entry.target_ssrc == 0xaabbccddu && entry.sequence_number == 7);
+  assert(!sfu_rtcp_fir_entry_at(&fir, 1, &entry));
+
+  sfu_rtcp_member_view bad = view;
+  bad.pt = 205; assert(!sfu_rtcp_parse_fir(&bad, &fir));
+  bad = view; bad.fmt_count = 1; assert(!sfu_rtcp_parse_fir(&bad, &fir));
+  bad = view; bad.member_len--; assert(!sfu_rtcp_parse_fir(&bad, &fir));
+  bad = view; bad.body_len = 11; assert(!sfu_rtcp_parse_fir(&bad, &fir));
+
+  uint8_t reserved[sizeof(packet)]; memcpy(reserved, packet, sizeof(packet));
+  reserved[19] = 1; bad = view_of(reserved, sizeof(reserved));
+  assert(!sfu_rtcp_parse_fir(&bad, &fir));
+}
+
+static void test_multiple_and_unaligned(void) {
+  const uint8_t packet[] = {
+      0x84, 206, 0, 6, 0, 0, 0, 1, 0, 0, 0, 0,
+      0, 0, 0, 2, 9, 0, 0, 0, 0, 0, 0, 3, 10, 0, 0, 0,
+  };
+  uint8_t storage[sizeof(packet) + 1]; memcpy(storage + 1, packet, sizeof(packet));
+  sfu_rtcp_member_view view = view_of(storage + 1, sizeof(packet));
+  sfu_rtcp_fir fir; sfu_rtcp_fir_entry entry;
+  assert(sfu_rtcp_parse_fir(&view, &fir) && fir.entry_count == 2);
+  assert(sfu_rtcp_fir_entry_at(&fir, 1, &entry));
+  assert(entry.target_ssrc == 3 && entry.sequence_number == 10);
+}
+
+int main(void) {
+  test_pli();
+  test_padding_logical_pli();
+  test_fir();
+  test_multiple_and_unaligned();
+  puts("rtcp fb tests passed");
+  return 0;
+}

--- a/tests/test_rtp_packet.c
+++ b/tests/test_rtp_packet.c
@@ -1,0 +1,104 @@
+#include "rtp/rtp_packet.h"
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void test_minimal_header(void) {
+  const uint8_t data[12] = {0x80, 0xe0, 0x12, 0x34, 0x01, 0x23, 0x45, 0x67,
+                            0x89, 0xab, 0xcd, 0xef};
+  sfu_rtp_packet_t packet;
+  assert(sfu_rtp_packet_parse(data, sizeof(data), &packet));
+  assert(packet.version == 2 && !packet.padding && !packet.extension);
+  assert(packet.csrc_count == 0 && packet.marker && packet.payload_type == 96);
+  assert(packet.sequence_number == 0x1234 && packet.timestamp == 0x01234567u);
+  assert(packet.ssrc == 0x89abcdefu && packet.header_len == 12);
+  assert(packet.payload == data + 12 && packet.payload_len == 0);
+}
+
+static void test_csrcs(void) {
+  const uint8_t data[21] = {0x82, 0x61, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3,
+                            0, 0, 0, 4, 0, 0, 0, 5, 0xaa};
+  sfu_rtp_packet_t packet;
+  assert(sfu_rtp_packet_parse(data, sizeof(data), &packet));
+  assert(packet.csrc_count == 2 && packet.header_len == 20);
+  assert(packet.payload == data + 20 && packet.payload_len == 1);
+}
+
+static void test_extension(void) {
+  const uint8_t data[23] = {0x90, 0x60, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3,
+                            0xbe, 0xde, 0, 1, 1, 2, 3, 4, 0xaa, 0xbb, 0xcc};
+  sfu_rtp_packet_t packet;
+  assert(sfu_rtp_packet_parse(data, sizeof(data), &packet));
+  assert(packet.extension && packet.extension_profile == 0xbede);
+  assert(packet.extension_data == data + 16 && packet.extension_length == 4);
+  assert(packet.header_len == 20 && packet.payload_len == 3);
+}
+
+static void test_malformed(void) {
+  uint8_t data[32] = {0x80, 0x60};
+  sfu_rtp_packet_t packet;
+  assert(!sfu_rtp_packet_parse(data, 11, &packet));
+  data[0] = 0x40;
+  assert(!sfu_rtp_packet_parse(data, 12, &packet));
+  data[0] = 0x8f;
+  assert(!sfu_rtp_packet_parse(data, 12, &packet));
+
+  data[0] = 0x90;
+  assert(!sfu_rtp_packet_parse(data, 15, &packet));
+  memset(data, 0, sizeof(data));
+  data[0] = 0x90;
+  data[14] = 0;
+  data[15] = 5;
+  assert(!sfu_rtp_packet_parse(data, 20, &packet));
+  assert(!sfu_rtp_packet_parse(NULL, 12, &packet));
+  assert(!sfu_rtp_packet_parse(data, 20, NULL));
+}
+
+static void test_padding(void) {
+  uint8_t data[17] = {0xa0, 0x60, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3,
+                      0xaa, 0xbb, 0, 0, 3};
+  sfu_rtp_packet_t packet;
+  assert(sfu_rtp_packet_parse(data, sizeof(data), &packet));
+  assert(packet.padding && packet.payload_len == 2);
+  data[16] = 0;
+  assert(!sfu_rtp_packet_parse(data, sizeof(data), &packet));
+  data[16] = 6;
+  assert(!sfu_rtp_packet_parse(data, sizeof(data), &packet));
+  assert(!sfu_rtp_packet_parse(data, 12, &packet));
+}
+
+static void test_unaligned_and_editors(void) {
+  uint8_t *raw = malloc(32);
+  uint8_t *data;
+  sfu_rtp_packet_t packet;
+  assert(raw != NULL);
+  data = raw + 1;
+  memset(data, 0, 16);
+  data[0] = 0x80;
+  data[1] = 0x80;
+  assert(sfu_rtp_packet_set_pt(data, 12, 111));
+  assert(sfu_rtp_packet_set_seq(data, 12, 0xa1b2));
+  assert(sfu_rtp_packet_set_ssrc(data, 12, 0x12345678u));
+  assert(sfu_rtp_packet_parse(data, 12, &packet));
+  assert(packet.marker && packet.payload_type == 111);
+  assert(packet.sequence_number == 0xa1b2 && packet.ssrc == 0x12345678u);
+  assert(!sfu_rtp_packet_set_pt(data, 11, 1));
+  assert(!sfu_rtp_packet_set_pt(data, 12, 128));
+  assert(!sfu_rtp_packet_set_seq(NULL, 12, 1));
+  assert(!sfu_rtp_packet_set_ssrc(data, 11, 1));
+  free(raw);
+}
+
+int main(void) {
+  test_minimal_header();
+  test_csrcs();
+  test_extension();
+  test_malformed();
+  test_padding();
+  test_unaligned_and_editors();
+  printf("test_rtp_packet: OK\n");
+  return 0;
+}

--- a/tests/test_rtx_build.c
+++ b/tests/test_rtx_build.c
@@ -1,0 +1,94 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "rtp/rtp_packet.h"
+#include "rtp/rtx_build.h"
+#include "util/netbytes.h"
+
+static void test_minimal_and_editor_fields(void) {
+  const uint8_t orig[] = {0x80, 0xe0, 0x12, 0x34, 0x01, 0x02, 0x03, 0x04,
+                          0x11, 0x22, 0x33, 0x44, 0xaa, 0xbb, 0xcc};
+  const uint8_t expected[] = {0x80, 0xe1, 0xbe, 0xef, 0x01, 0x02, 0x03, 0x04,
+                              0x55, 0x66, 0x77, 0x88, 0x12, 0x34, 0xaa, 0xbb,
+                              0xcc};
+  uint8_t out[sizeof(orig) + 2u];
+  size_t out_len = 0;
+  sfu_rtp_packet_t packet;
+
+  assert(sfu_rtx_build(orig, sizeof(orig), 97, 0xbeef, 0x55667788u, out,
+                       sizeof(out), &out_len));
+  assert(out_len == sizeof(expected));
+  assert(memcmp(out, expected, sizeof(expected)) == 0);
+  assert(sfu_rtp_packet_parse(out, out_len, &packet));
+  assert(packet.marker && packet.payload_type == 97);
+  assert(packet.sequence_number == 0xbeef && packet.timestamp == 0x01020304u);
+  assert(packet.ssrc == 0x55667788u && packet.payload_len == 5u);
+}
+
+static void test_csrc_extension_and_unaligned(void) {
+  const uint8_t orig[] = {
+      0x92, 0x62, 0x22, 0x33, 0x10, 0x20, 0x30, 0x40, 0x01, 0x02, 0x03, 0x04,
+      0xaa, 0xbb, 0xcc, 0xdd, 0x11, 0x22, 0x33, 0x44, 0xbe, 0xde, 0x00, 0x02,
+      0x10, 0x11, 0x12, 0x13, 0x20, 0x21, 0x22, 0x23, 0xde, 0xad};
+  uint8_t storage[sizeof(orig) + 4u];
+  uint8_t *out = storage + 1u;
+  size_t out_len = 99;
+  sfu_rtp_packet_t packet;
+
+  assert(sfu_rtx_build(orig, sizeof(orig), 99, 7, 0xa1a2a3a4u, out,
+                       sizeof(orig) + 2u, &out_len));
+  assert(out_len == sizeof(orig) + 2u);
+  assert(sfu_rtp_packet_parse(out, out_len, &packet));
+  assert(packet.header_len == 32u && packet.csrc_count == 2u);
+  assert(packet.extension && packet.extension_profile == 0xbede);
+  assert(packet.extension_length == 8u);
+  assert(memcmp(out + 12u, orig + 12u, 20u) == 0);
+  assert(sfu_read_be16(out + packet.header_len) == 0x2233);
+  assert(out[packet.header_len + 2u] == 0xde && out[packet.header_len + 3u] == 0xad);
+}
+
+static void test_padding_stripped(void) {
+  const uint8_t orig[] = {0xa0, 0x60, 0x00, 0x09, 0, 0, 0, 1, 0, 0, 0, 2,
+                          0x41, 0x42, 0, 0, 0, 4};
+  uint8_t out[sizeof(orig) + 2u];
+  size_t out_len = 0;
+  sfu_rtp_packet_t packet;
+
+  assert(sfu_rtx_build(orig, sizeof(orig), 100, 10, 3, out, sizeof(out), &out_len));
+  assert(out_len == 16u);
+  assert((out[0] & 0x20u) == 0);
+  assert(sfu_rtp_packet_parse(out, out_len, &packet));
+  assert(!packet.padding && packet.payload_len == 4u);
+  assert(sfu_read_be16(packet.payload) == 9u);
+  assert(packet.payload[2] == 0x41 && packet.payload[3] == 0x42);
+}
+
+static void test_failures_and_capacity(void) {
+  const uint8_t orig[] = {0x80, 0x60, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3, 0xaa};
+  const uint8_t malformed[] = {0x90, 0x60, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3};
+  uint8_t out[sizeof(orig) + 2u];
+  uint8_t canary[sizeof(out)];
+  size_t out_len = 0xabcdefu;
+
+  memset(out, 0xa5, sizeof(out));
+  memcpy(canary, out, sizeof(out));
+  assert(!sfu_rtx_build(orig, sizeof(orig), 98, 2, 4, out, sizeof(out) - 1u,
+                        &out_len));
+  assert(memcmp(out, canary, sizeof(out)) == 0 && out_len == 0xabcdefu);
+  assert(!sfu_rtx_build(malformed, sizeof(malformed), 98, 2, 4, out,
+                        sizeof(out), &out_len));
+  assert(memcmp(out, canary, sizeof(out)) == 0 && out_len == 0xabcdefu);
+  assert(sfu_rtx_build(orig, sizeof(orig), 98, 2, 4, out, sizeof(out), &out_len));
+  assert(out_len == sizeof(out));
+}
+
+int main(void) {
+  test_minimal_and_editor_fields();
+  test_csrc_extension_and_unaligned();
+  test_padding_stripped();
+  test_failures_and_capacity();
+  return 0;
+}

--- a/tests/test_rtx_capacity.c
+++ b/tests/test_rtx_capacity.c
@@ -1,0 +1,79 @@
+#include "rtp/rtx.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "sfu/datadef.h"
+
+#define EXPECT(cond)                                                       \
+  do {                                                                     \
+    if (!(cond)) {                                                         \
+      fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond);      \
+      return 1;                                                            \
+    }                                                                      \
+  } while (0)
+
+/*
+ * RTX capacity / init-hardening tests (P0.5).
+ *
+ * No project-wide failing-allocator hook exists, so the OOM branch in
+ * sfu_rtx_cache_init cannot be forced from this binary. Instead we:
+ *   1. Verify put/get size gate (room for 2-byte RTX OSN):
+ *        len == SFU_MAX_PAYLOAD_SIZE - 2  -> accepted
+ *        len == SFU_MAX_PAYLOAD_SIZE - 1  -> rejected
+ *        len == SFU_MAX_PAYLOAD_SIZE      -> rejected
+ *   2. Verify destroy is safe on a zeroed cache (the state left after an
+ *      init-failure cleanup path frees already-allocated entry buffers).
+ */
+int main(void) {
+  /* --- init-failure leftover: zeroed cache must be destroy-safe --- */
+  {
+    sfu_rtx_cache_t zeroed;
+    memset(&zeroed, 0, sizeof(zeroed));
+    sfu_rtx_cache_destroy(&zeroed); /* must not crash / free garbage */
+  }
+
+  /* --- happy-path init --- */
+  sfu_rtx_cache_t cache;
+  EXPECT(sfu_rtx_cache_init(&cache) == 0);
+
+  uint8_t *buf = (uint8_t *)malloc(SFU_MAX_PAYLOAD_SIZE);
+  EXPECT(buf != NULL);
+  memset(buf, 0xA5, SFU_MAX_PAYLOAD_SIZE);
+
+  uint8_t out[SFU_MAX_PAYLOAD_SIZE];
+  uint32_t out_len = 0;
+  uint32_t out_ssrc = 0;
+  uint8_t out_pt = 0;
+
+  /* Boundary: max cacheable length leaves 2 bytes for RTX OSN. */
+  const uint32_t ok_len = SFU_MAX_PAYLOAD_SIZE - 2;
+  sfu_rtx_cache_put(&cache, 100, buf, ok_len, 0x11223344u, 96);
+  EXPECT(sfu_rtx_cache_get(&cache, 100, out, &out_len, &out_ssrc, &out_pt));
+  EXPECT(out_len == ok_len);
+  EXPECT(out_ssrc == 0x11223344u);
+  EXPECT(out_pt == 96);
+  EXPECT(memcmp(out, buf, ok_len) == 0);
+
+  /* One byte over the safe expand limit: must not be cached. */
+  sfu_rtx_cache_put(&cache, 200, buf, SFU_MAX_PAYLOAD_SIZE - 1, 1u, 97);
+  EXPECT(!sfu_rtx_cache_get(&cache, 200, out, &out_len, &out_ssrc, &out_pt));
+
+  /* Full payload size: must not be cached. */
+  sfu_rtx_cache_put(&cache, 300, buf, SFU_MAX_PAYLOAD_SIZE, 2u, 98);
+  EXPECT(!sfu_rtx_cache_get(&cache, 300, out, &out_len, &out_ssrc, &out_pt));
+
+  /* Earlier accepted entry is still intact. */
+  EXPECT(sfu_rtx_cache_get(&cache, 100, out, &out_len, &out_ssrc, &out_pt));
+  EXPECT(out_len == ok_len);
+
+  free(buf);
+  sfu_rtx_cache_destroy(&cache);
+
+  /* Double-destroy after destroy nulls entry pointers must be safe. */
+  sfu_rtx_cache_destroy(&cache);
+
+  printf("test_rtx_capacity: OK\n");
+  return 0;
+}

--- a/tests/test_session_table.c
+++ b/tests/test_session_table.c
@@ -2,10 +2,12 @@
 #include "protocol/signaling/signaling.h"
 #include "runtime/routing_context.h"
 #include "transport/dtls/dtls.h"
+#include "util/alloc.h"
 
 #include <arpa/inet.h>
 #include <assert.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 static void make_addr(struct sockaddr_storage *addr, socklen_t *len, const char *ip, uint16_t port) {
@@ -65,6 +67,24 @@ int main(void) {
   assert(sfu_session_table_find(&table, &addr3, len3) == s1);
 
   /* 5. Remove session & tombstone checks */
+  s1->receivers = SFU_CALLOC(2, sizeof(*s1->receivers));
+  assert(s1->receivers != NULL);
+  s1->receiver_capacity = 2;
+  s1->receivers[0] = SFU_CALLOC(1, sizeof(*s1->receivers[0]));
+  assert(s1->receivers[0] != NULL);
+  s1->receivers[1] = SFU_CALLOC(1, sizeof(*s1->receivers[1]));
+  assert(s1->receivers[1] != NULL);
+
+  s2->receivers = SFU_CALLOC(3, sizeof(*s2->receivers));
+  assert(s2->receivers != NULL);
+  s2->receiver_capacity = 3;
+  s2->receivers[0] = SFU_CALLOC(1, sizeof(*s2->receivers[0]));
+  assert(s2->receivers[0] != NULL);
+  s2->receivers[1] = SFU_CALLOC(1, sizeof(*s2->receivers[1]));
+  assert(s2->receivers[1] != NULL);
+  s2->receivers[2] = SFU_CALLOC(1, sizeof(*s2->receivers[2]));
+  assert(s2->receivers[2] != NULL);
+
   sfu_session_table_remove(&table, s1);
   assert(sfu_session_table_find(&table, &addr3, len3) == NULL);
   assert(sfu_session_table_find_by_ufrag(&table, "ufrag_alice") == NULL);

--- a/tests/test_valkey_queue.c
+++ b/tests/test_valkey_queue.c
@@ -1,0 +1,141 @@
+#include <assert.h>
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdlib.h>
+
+#include "cache/valkey_queue.h"
+
+typedef struct test_stats {
+  atomic_size_t consumed;
+  atomic_size_t disposed;
+} test_stats_t;
+
+static void consume_item(void *item, void *arg) {
+  test_stats_t *stats = arg;
+  free(item);
+  atomic_fetch_add(&stats->consumed, 1);
+}
+
+static void dispose_pending(void *item, void *arg) {
+  test_stats_t *stats = arg;
+  free(item);
+  atomic_fetch_add(&stats->disposed, 1);
+}
+
+static void *new_item(void) {
+  void *item = malloc(1);
+  assert(item);
+  return item;
+}
+
+static void test_invalid_arguments(void) {
+  test_stats_t stats = {0};
+  valkey_queue_t queue;
+  assert(valkey_queue_init(NULL, dispose_pending, &stats) != 0);
+  assert(valkey_queue_init(&queue, NULL, &stats) != 0);
+  assert(valkey_queue_init(&queue, dispose_pending, &stats) == 0);
+  void *orphan = new_item();
+  assert(valkey_queue_post(NULL, orphan) == VALKEY_QUEUE_INVALID);
+  free(orphan);
+  assert(valkey_queue_post(&queue, NULL) == VALKEY_QUEUE_INVALID);
+  assert(valkey_queue_drain(NULL, consume_item, &stats) == 0);
+  assert(valkey_queue_drain(&queue, NULL, &stats) == 0);
+  valkey_queue_close(NULL);
+  valkey_queue_destroy_after_producers_stopped(&queue);
+}
+
+static void test_capacity_and_drain(void) {
+  test_stats_t stats = {0};
+  valkey_queue_t queue;
+  assert(valkey_queue_init(&queue, dispose_pending, &stats) == 0);
+  for (size_t i = 0; i < VALKEY_QUEUE_CAPACITY; i++) {
+    assert(valkey_queue_post(&queue, new_item()) == VALKEY_QUEUE_OK);
+  }
+  void *extra = new_item();
+  assert(valkey_queue_post(&queue, extra) == VALKEY_QUEUE_FULL);
+  free(extra);
+  assert(valkey_queue_drain(&queue, consume_item, &stats) == VALKEY_QUEUE_CAPACITY);
+  assert(atomic_load(&stats.consumed) == VALKEY_QUEUE_CAPACITY);
+  assert(valkey_queue_drain(&queue, consume_item, &stats) == 0);
+  valkey_queue_destroy_after_producers_stopped(&queue);
+}
+
+typedef struct producer {
+  valkey_queue_t *queue;
+  size_t accepted;
+} producer_t;
+
+static void *produce(void *arg) {
+  producer_t *producer = arg;
+  for (size_t i = 0; i < 64; i++) {
+    void *item = new_item();
+    valkey_queue_post_result_t result = valkey_queue_post(producer->queue, item);
+    if (result == VALKEY_QUEUE_OK) {
+      producer->accepted++;
+    } else {
+      assert(result == VALKEY_QUEUE_FULL);
+      free(item);
+    }
+  }
+  return NULL;
+}
+
+static void test_concurrent_producers(void) {
+  test_stats_t stats = {0};
+  valkey_queue_t queue;
+  pthread_t threads[8];
+  producer_t producers[8] = {0};
+  size_t accepted = 0;
+  assert(valkey_queue_init(&queue, dispose_pending, &stats) == 0);
+  for (size_t i = 0; i < 8; i++) {
+    producers[i].queue = &queue;
+    assert(pthread_create(&threads[i], NULL, produce, &producers[i]) == 0);
+  }
+  for (size_t i = 0; i < 8; i++) {
+    pthread_join(threads[i], NULL);
+    accepted += producers[i].accepted;
+  }
+  assert(accepted == VALKEY_QUEUE_CAPACITY);
+  assert(valkey_queue_drain(&queue, consume_item, &stats) == accepted);
+  assert(atomic_load(&stats.consumed) == accepted);
+  valkey_queue_destroy_after_producers_stopped(&queue);
+}
+
+static void test_close_and_pending(void) {
+  test_stats_t stats = {0};
+  valkey_queue_t queue;
+  assert(valkey_queue_init(&queue, dispose_pending, &stats) == 0);
+  for (size_t i = 0; i < 17; i++) {
+    assert(valkey_queue_post(&queue, new_item()) == VALKEY_QUEUE_OK);
+  }
+  valkey_queue_close(&queue);
+  valkey_queue_close(&queue);
+  void *extra = new_item();
+  assert(valkey_queue_post(&queue, extra) == VALKEY_QUEUE_CLOSED);
+  free(extra);
+  valkey_queue_destroy_after_producers_stopped(&queue);
+  assert(atomic_load(&stats.disposed) == 17);
+}
+
+static void test_public_wraparound(void) {
+  test_stats_t stats = {0};
+  valkey_queue_t queue;
+  assert(valkey_queue_init(&queue, dispose_pending, &stats) == 0);
+  for (size_t round = 0; round < 3; round++) {
+    for (size_t i = 0; i < VALKEY_QUEUE_CAPACITY; i++) {
+      assert(valkey_queue_post(&queue, new_item()) == VALKEY_QUEUE_OK);
+    }
+    assert(valkey_queue_drain(&queue, consume_item, &stats) == VALKEY_QUEUE_CAPACITY);
+  }
+  assert(atomic_load(&stats.consumed) == 3 * VALKEY_QUEUE_CAPACITY);
+  valkey_queue_destroy_after_producers_stopped(&queue);
+}
+
+int main(void) {
+  test_invalid_arguments();
+  test_capacity_and_drain();
+  test_concurrent_producers();
+  test_close_and_pending();
+  test_public_wraparound();
+  return 0;
+}


### PR DESCRIPTION
## Summary

This is the first integration batch from the security review. It adds safety
fixes, protocol foundations, and tests without wiring the new protocol modules
into the hot forwarding path yet.

### Runtime safety

- Drop `MSG_TRUNC` datagrams instead of dispatching truncated RTP/RTCP/STUN.
- Reject zero-capacity JSON output buffers before any write.
- Reject invalid worker counts in startup, fanout init, and receive dispatch.
- Centralize session resource teardown and remove the deterministic receiver
  double-free.
- Fix receiver-slot cleanup in session creation failure paths.
- Make RTX cache initialization fail cleanly on allocation failure.
- Prevent caching packets that cannot be expanded by the RTX OSN.
- Check RTX output capacity before rebuilding.

### Epoch reclamation

- Extract deferred reclamation into `sfu_epoch_reclaimer`.
- Use a fixed retire-node pool and explicit destructor callbacks.
- Remove the unsafe timeout-then-free fallback.
- Return ownership to callers when retirement capacity is exhausted.
- Add stall, exhaustion, concurrent retire/sweep, and shutdown drain tests.

### Protocol primitives

- Add alignment-safe big-endian helpers in `util/netbytes.h`.
- Add strict RTP packet parsing and safe PT/sequence/SSRC editors.
- Add a compound RTCP member iterator with version, length, and padding checks.
- Add validated PLI and FIR feedback parsers.
- Add a checked RFC 4588 RTX builder that handles CSRCs and RTP extensions and
  strips original padding deliberately.
- Replace unaligned TWCC integer loads with byte-safe reads.

### Queue and observability

- Add a bounded, per-owner Valkey queue module with explicit `OK`, `FULL`,
  `CLOSED`, and `INVALID` ownership semantics.
- Add a minimal atomic metrics registry.
- Note: the legacy `valkey_client.c` integration is intentionally not changed;
  it is currently not built in-tree and depends on missing cache sources.

## Test plan

- Debug: `ctest --output-on-failure -E '^sdp$'` — 20/20 passed.
- ASan/UBSan: `ctest --output-on-failure -E '^sdp$'` — 20/20 passed.
- New tests cover JSON zero-capacity guards, RTP/RTCP boundary and malformed
  inputs, RTX capacity and variable-header construction, epoch reclamation,
  Valkey queue saturation/concurrency, netbytes, and metrics.
- `sdp` is excluded because it was already failing before this batch.

## Not included yet

These follow-up changes are intentionally left out of this foundational batch:

- Runtime worker wiring for compound RTCP dispatch.
- Session pinning and immutable receiver snapshots.
- Media-SSRC-scoped RTX cache and keyframe routing.
- SVC/scheduler split.
- TWCC/GCC rewrite and pacer.
- Legacy Valkey client lifecycle migration.