### PR TITLE
Wire compound RTCP dispatch and checked RTX building

### DIFF
--- a/src/rtp/rtx.c
+++ b/src/rtp/rtx.c
@@ -1,31 +1,48 @@
 #include "rtx.h"
-#include <arpa/inet.h>
 #include <stdlib.h>
 #include <string.h>
 #include "sfu/datadef.h"
 #include "util/alloc.h"
+#include "util/netbytes.h"
 
-void sfu_nack_parser_init(sfu_nack_parser_t *parser, const uint8_t *data, uint32_t len) {
+bool sfu_nack_parser_init(sfu_nack_parser_t *parser, const uint8_t *data, size_t len) {
+  memset(parser, 0, sizeof(*parser));
   // RTCP Header (4) + Sender SSRC (4) + Media SSRC (4) = 12 bytes
-  if (len < 16) {  // Must have at least one 4-byte NACK block
-    parser->nack_ptr = NULL;
-    return;
+  if (!data || len < 16) {  // Must have at least one 4-byte NACK block
+    return false;
+  }
+  // Must be a generic NACK feedback member: PT=205, FMT=1.
+  if ((data[0] >> 6) != 2 || (data[0] & 0x1F) != 1 || data[1] != 205) {
+    return false;
+  }
+  size_t fci_len = len - 12;
+  if ((fci_len % 4) != 0) {
+    return false;
   }
   parser->nack_ptr = data + 12;
   parser->nack_end = data + len;
+  parser->media_ssrc = sfu_read_be32(data + 8);
   parser->bit_index = 16;  // Force immediate read of the first block
+  return true;
 }
+
+uint32_t sfu_nack_parser_media_ssrc(const sfu_nack_parser_t *parser) { return parser->media_ssrc; }
 
 bool sfu_nack_parser_next(sfu_nack_parser_t *parser, uint16_t *lost_seq) {
   if (!parser->nack_ptr) {
     return false;
   }
 
-  while (parser->nack_ptr < parser->nack_end) {
-    // If we exhausted the previous 16-bit mask, load the next NACK block
+  for (;;) {
+    // If we exhausted the previous 16-bit mask, load the next NACK block.
+    // The pointer reaches nack_end as soon as the final block is loaded, but
+    // that block's PID/BLP still has to be yielded before iteration ends.
     if (parser->bit_index > 15) {
-      parser->current_pid = ntohs(*(uint16_t *)(parser->nack_ptr));
-      parser->current_blp = ntohs(*(uint16_t *)(parser->nack_ptr + 2));
+      if ((size_t)(parser->nack_end - parser->nack_ptr) < 4) {
+        break;  // Defensive: init guarantees a 4-byte multiple FCI.
+      }
+      parser->current_pid = sfu_read_be16(parser->nack_ptr);
+      parser->current_blp = sfu_read_be16(parser->nack_ptr + 2);
       parser->nack_ptr += 4;
       parser->bit_index = -1;  // -1 signals to return the base PID itself
     }
@@ -37,9 +54,11 @@ bool sfu_nack_parser_next(sfu_nack_parser_t *parser, uint16_t *lost_seq) {
       return true;
     }
 
-    // Iterate through the 16-bit BLP mask to find additional lost packets
+    // Iterate through the 16-bit BLP mask to find additional lost packets.
+    // bit_index counts mask bits starting at the LSB: bit i set means
+    // packet PID + i + 1 is also lost.
     while (parser->bit_index < 16) {
-      bool is_lost = (parser->current_blp & (1 << parser->bit_index)) != 0;
+      bool is_lost = (parser->current_blp & (1u << parser->bit_index)) != 0;
       int offset = parser->bit_index + 1;
       parser->bit_index++;
 

--- a/src/rtp/rtx.h
+++ b/src/rtp/rtx.h
@@ -2,6 +2,7 @@
 #define SFU_RTX_H
 
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 #define SFU_RTX_CACHE_SIZE 1024
@@ -25,6 +26,7 @@ typedef struct sfu_rtx_cache {
 typedef struct {
   const uint8_t *nack_ptr;
   const uint8_t *nack_end;
+  uint32_t media_ssrc;
   uint16_t current_pid;
   uint16_t current_blp;
   int bit_index;
@@ -35,7 +37,10 @@ void sfu_rtx_cache_put(sfu_rtx_cache_t *cache, uint16_t seq, const uint8_t *data
 bool sfu_rtx_cache_get(sfu_rtx_cache_t *cache, uint16_t seq, uint8_t *out_data, uint32_t *out_len, uint32_t *out_rtx_ssrc, uint8_t *out_rtx_pt);
 void sfu_rtx_cache_destroy(sfu_rtx_cache_t *cache);
 
-void sfu_nack_parser_init(sfu_nack_parser_t *parser, const uint8_t *data, uint32_t len);
+/* Initialize from one exact, unpadded RTCP RTPFB/NACK member. Returns false
+ * unless PT=205/FMT=1 and the FCI is a non-empty multiple of four bytes. */
+bool sfu_nack_parser_init(sfu_nack_parser_t *parser, const uint8_t *data, size_t len);
+uint32_t sfu_nack_parser_media_ssrc(const sfu_nack_parser_t *parser);
 bool sfu_nack_parser_next(sfu_nack_parser_t *parser, uint16_t *lost_seq);
 
 #endif  // SFU_RTX_H

--- a/src/runtime/worker.c
+++ b/src/runtime/worker.c
@@ -8,13 +8,18 @@
 #include "media/svc/vp9_parser.h"
 #include "peer/session.h"
 #include "pipeline/dispatch.h"
+#include "rtcp/rtcp_compound.h"
+#include "rtcp/rtcp_fb.h"
+#include "rtp/rtp_packet.h"
 #include "rtp/rtx.h"
+#include "rtp/rtx_build.h"
 #include "runtime/cpu.h"
 #include "runtime/scheduler.h"
 #include "runtime/signal.h"
 #include "runtime/timer.h"
 #include "transport/srtp/srtp.h"
 #include "util/log.h"
+#include "util/metrics.h"
 #include "util/netbytes.h"
 
 #define SFU_WORKER_SEND_SQ_ENTRIES 1024
@@ -64,27 +69,25 @@ void sfu_worker_destroy(sfu_worker_t *w) {
   sfu_spsc_ring_destroy(&w->inbox);
 }
 
+/* Strict RTP header walk via the shared parser. Same accept/reject semantics
+ * as the old inline helper (no version check, extension fully bounded), plus
+ * padding validation, which is behavior-safe here because VP9 media is never
+ * sent padded. Returns payload offset or -1. */
 static int sfu_rtp_get_payload_offset(const uint8_t *data, uint32_t len) {
-  if (len < 12) {
+  sfu_rtp_packet_t packet;
+  if (!sfu_rtp_packet_parse(data, len, &packet)) {
     return -1;
   }
-  uint8_t csrc_count = data[0] & 0x0F;
-  uint32_t offset = 12 + (csrc_count * 4);
-
-  if (len < offset) {
-    return -1;
-  }
-
-  if (data[0] & 0x10) {
-    if (len < offset + 4) {
-      return -1;
-    }
-    uint16_t ext_len = (data[offset + 2] << 8) | data[offset + 3];
-    offset += 4 + (ext_len * 4);
-  }
-
-  return (offset <= len) ? (int)offset : -1;
+  return (int)packet.header_len;
 }
+
+// Cap on distinct lost sequence numbers serviced per NACK member; bounds work
+// per feedback packet and dedups expanded BLP runs.
+#define SFU_WORKER_NACK_REQUEST_CAP 48
+
+// Throttle keyframe requests triggered by feedback to one per second per
+// session, mirroring the pre-Phase-2 behavior.
+#define SFU_WORKER_KF_THROTTLE_MS 1000
 
 static void sfu_svc_update_layers(sfu_peer_session_t *session, uint32_t bitrate_bps) {
   // Example VP9 bitrate ladder
@@ -101,6 +104,200 @@ static void sfu_svc_update_layers(sfu_peer_session_t *session, uint32_t bitrate_
     session->target_sid = 0;
     session->target_tid = 0;  // Lowest framerate
   }
+}
+
+static void sfu_worker_request_keyframe_throttled(sfu_worker_t *w, sfu_peer_session_t *session) {
+  // NOTE: session here is the session the feedback arrived on. True
+  // Media-SSRC -> publisher session routing lands with the session/stream
+  // lookup rework in the next phase.
+  int64_t now = (int64_t)sfu_now_ms();
+  if (now - session->last_pli_time > SFU_WORKER_KF_THROTTLE_MS) {
+    session->last_pli_time = now;
+    sfu_session_request_keyframe(w, session, false);  // false = PLI
+  }
+}
+
+static void sfu_worker_handle_twcc_member(sfu_worker_t *w, sfu_peer_session_t *sender_session, const sfu_rtcp_member_view *view) {
+  sfu_twcc_parser_t parser;
+  // Bound the parser to this member's logical (unpadded) bytes.
+  if (sfu_twcc_parser_init(&parser, view->member, view->member_len) != 0) {
+    sfu_metric_inc("rtcp_twcc_bad");
+    return;
+  }
+
+  gcc_packet_info_t twcc_pkt;
+  uint32_t estimated_bps = 0;
+
+  if (sender_session->gcc_ctx) {
+    estimated_bps = sender_session->gcc_ctx->aimd.current_bitrate_bps;
+  }
+
+  while (sfu_twcc_parser_next(&parser, &twcc_pkt)) {
+    if (sender_session->twcc_history && sfu_twcc_history_lookup(sender_session->twcc_history, twcc_pkt.sequence_number, &twcc_pkt)) {
+      if (sender_session->gcc_ctx) {
+        estimated_bps = gcc_bwe_process_twcc_packet(sender_session->gcc_ctx, &twcc_pkt);
+      }
+    }
+  }
+
+  if (estimated_bps > 0) {
+    sfu_svc_update_layers(sender_session, estimated_bps);
+  }
+  (void)w;
+}
+
+static void sfu_worker_handle_nack_member(sfu_worker_t *w, sfu_peer_session_t *sender_session, const sfu_rtcp_member_view *view) {
+  sfu_nack_parser_t nack_parser;
+  if (!sfu_nack_parser_init(&nack_parser, view->member, view->member_len)) {
+    sfu_metric_inc("rtcp_nack_bad");
+    return;
+  }
+
+  if (!sender_session->rtx_cache) {
+    return;
+  }
+
+  // NOTE: lookup stays on the existing per-session RTX cache regardless of
+  // the NACK media SSRC; stream-scoped RTX caches are a later phase.
+  uint32_t nack_media_ssrc = sfu_nack_parser_media_ssrc(&nack_parser);
+  (void)nack_media_ssrc;
+
+  uint16_t requested[SFU_WORKER_NACK_REQUEST_CAP];
+  uint32_t requested_count = 0;
+  bool capped = false;
+
+  uint16_t lost_seq;
+  bool unrecoverable_loss = false;
+  while (sfu_nack_parser_next(&nack_parser, &lost_seq)) {
+    bool duplicate = false;
+    for (uint32_t i = 0; i < requested_count; i++) {
+      if (requested[i] == lost_seq) {
+        duplicate = true;
+        break;
+      }
+    }
+    if (duplicate) {
+      continue;
+    }
+    if (requested_count >= SFU_WORKER_NACK_REQUEST_CAP) {
+      capped = true;
+      break;
+    }
+    requested[requested_count++] = lost_seq;
+
+    uint8_t orig_pkt[SFU_MAX_PAYLOAD_SIZE];
+    uint32_t orig_len = 0;
+    uint32_t rtx_ssrc = 0;
+    uint8_t rtx_pt = 0;
+
+    if (sfu_rtx_cache_get(sender_session->rtx_cache, lost_seq, orig_pkt, &orig_len, &rtx_ssrc, &rtx_pt)) {
+      sfu_packet_t *rtx_enc = sfu_packet_pool_alloc(w->pp);
+      if (!rtx_enc) {
+        continue;
+      }
+
+      uint16_t next_rtx_seq = __atomic_fetch_add(&sender_session->rtx_cache->next_rtx_seq, 1, __ATOMIC_RELAXED);
+      size_t rtx_built_len = 0;
+      // sfu_rtx_build conservatively requires orig_len + 2 bytes of output
+      // capacity; the cache only stores packets with len + 2 <=
+      // SFU_MAX_PAYLOAD_SIZE <= pool buffer cap, so a successful get always
+      // fits. On failure the scratch buffer is untouched.
+      if (!sfu_rtx_build(orig_pkt, orig_len, rtx_pt, next_rtx_seq, rtx_ssrc, rtx_enc->data, rtx_enc->cap, &rtx_built_len)) {
+        sfu_metric_inc("rtx_build_fail");
+        sfu_worker_release_packet(w->pp, &w->release_to_dispatcher, rtx_enc);
+        continue;
+      }
+
+      int rtx_enc_len = (int)rtx_built_len;
+      if (sfu_srtp_protect_rtp(&sender_session->srtp, rtx_enc->data, &rtx_enc_len, rtx_enc->cap)) {
+        rtx_enc->len = (uint32_t)rtx_enc_len;
+        sfu_ring_queue_send_zc(&w->send_ring, rtx_enc, (const struct sockaddr *)&sender_session->cold->addr, sender_session->cold->addr_len);
+      }
+      sfu_worker_release_packet(w->pp, &w->release_to_dispatcher, rtx_enc);
+    } else {
+      unrecoverable_loss = true;
+    }
+  }
+
+  if (capped) {
+    sfu_metric_inc("rtcp_nack_dropped");
+  }
+
+  if (unrecoverable_loss) {
+    // On cache miss keep the existing keyframe fallback. Follow-up: route by
+    // media SSRC once stream-scoped lookup lands.
+    sfu_worker_request_keyframe_throttled(w, sender_session);
+  }
+}
+
+static void sfu_worker_handle_pli_member(sfu_worker_t *w, sfu_peer_session_t *sender_session, const sfu_rtcp_member_view *view) {
+  sfu_rtcp_pli pli;
+  if (!sfu_rtcp_parse_pli(view, &pli)) {
+    sfu_metric_inc("rtcp_pli_bad");
+    return;
+  }
+  // NOTE: pli.media_ssrc is parsed and validated, but the keyframe request is
+  // still issued via the existing session path; Media-SSRC publisher routing
+  // is next phase.
+  sfu_worker_request_keyframe_throttled(w, sender_session);
+}
+
+static void sfu_worker_handle_fir_member(sfu_worker_t *w, sfu_peer_session_t *sender_session, const sfu_rtcp_member_view *view) {
+  sfu_rtcp_fir fir;
+  if (!sfu_rtcp_parse_fir(view, &fir)) {
+    sfu_metric_inc("rtcp_pli_bad");
+    return;
+  }
+  // Minimal handling: subscribers are not supposed to FIR the SFU; log only.
+  SFU_LOG_DEBUG("worker %u: RTCP FIR from peer %u (media_ssrc=%u, %zu entries) ignored", w->worker_index, sender_session->peer_id, fir.media_ssrc,
+                fir.entry_count);
+}
+
+/* Iterate the (already SRTCP-unprotected) compound RTCP packet and dispatch
+ * every valid member. A malformed member drops the remainder of the compound
+ * and bumps rtcp_compound_malformed. Consumes pkt; never forwards it. */
+static void sfu_worker_handle_rtcp(sfu_worker_t *w, sfu_peer_session_t *sender_session, sfu_packet_t *pkt) {
+  sfu_rtcp_compound_iter iter;
+  sfu_rtcp_compound_iter_init(&iter, pkt->data, pkt->len);
+
+  sfu_rtcp_member_view view;
+  for (;;) {
+    sfu_rtcp_compound_result rc = sfu_rtcp_compound_iter_next(&iter, &view);
+    if (rc == SFU_RTCP_COMPOUND_END) {
+      break;
+    }
+    if (rc == SFU_RTCP_COMPOUND_MALFORMED) {
+      sfu_metric_inc("rtcp_compound_malformed");
+      break;
+    }
+
+    switch (view.pt) {
+      case 205:  // RTPFB
+        if (view.fmt_count == 15) {
+          sfu_worker_handle_twcc_member(w, sender_session, &view);
+        } else if (view.fmt_count == 1) {
+          sfu_worker_handle_nack_member(w, sender_session, &view);
+        } else {
+          sfu_metric_inc("rtcp_member_unknown");
+        }
+        break;
+      case 206:  // PSFB
+        if (view.fmt_count == 1) {
+          sfu_worker_handle_pli_member(w, sender_session, &view);
+        } else if (view.fmt_count == 4) {
+          sfu_worker_handle_fir_member(w, sender_session, &view);
+        } else {
+          sfu_metric_inc("rtcp_member_unknown");
+        }
+        break;
+      default:
+        // SR/RR/SDES/BYE and anything else: no worker action this phase.
+        sfu_metric_inc("rtcp_member_unknown");
+        break;
+    }
+  }
+
+  sfu_worker_release_packet(w->pp, &w->release_to_dispatcher, pkt);
 }
 
 void sfu_room_forward_packet(sfu_worker_t *w, sfu_packet_t *pkt) {
@@ -129,103 +326,9 @@ void sfu_room_forward_packet(sfu_worker_t *w, sfu_packet_t *pkt) {
   }
   pkt->len = (uint32_t)plain_len;
 
-  if (is_rtcp && pkt->len >= 12) {
-    uint8_t fmt = pkt->data[0] & 0x1F;
-    uint8_t pt = pkt->data[1];
-
-    if (pt == 205 && fmt == 15) {
-      sfu_twcc_parser_t parser;
-
-      if (sfu_twcc_parser_init(&parser, pkt->data, pkt->len) == 0) {
-        gcc_packet_info_t twcc_pkt;
-        uint32_t estimated_bps = 0;
-
-        if (sender_session->gcc_ctx) {
-          estimated_bps = sender_session->gcc_ctx->aimd.current_bitrate_bps;
-        }
-
-        while (sfu_twcc_parser_next(&parser, &twcc_pkt)) {
-          if (sender_session->twcc_history && sfu_twcc_history_lookup(sender_session->twcc_history, twcc_pkt.sequence_number, &twcc_pkt)) {
-            if (sender_session->gcc_ctx) {
-              estimated_bps = gcc_bwe_process_twcc_packet(sender_session->gcc_ctx, &twcc_pkt);
-            }
-          }
-        }
-
-        if (estimated_bps > 0) {
-          sfu_svc_update_layers(sender_session, estimated_bps);
-        }
-      }
-      sfu_worker_release_packet(w->pp, &w->release_to_dispatcher, pkt);
-      return;
-    } else if (pt == 205 && fmt == 1) {
-      if (!sender_session->rtx_cache) {
-        sfu_worker_release_packet(w->pp, &w->release_to_dispatcher, pkt);
-        return;
-      }
-
-      sfu_nack_parser_t nack_parser;
-      sfu_nack_parser_init(&nack_parser, pkt->data, pkt->len);
-
-      uint16_t lost_seq;
-      bool unrecoverable_loss = false;
-      while (sfu_nack_parser_next(&nack_parser, &lost_seq)) {
-        uint8_t orig_pkt[SFU_MAX_PAYLOAD_SIZE];
-        uint32_t orig_len = 0;
-        uint32_t rtx_ssrc = 0;
-        uint8_t rtx_pt = 0;
-
-        if (sfu_rtx_cache_get(sender_session->rtx_cache, lost_seq, orig_pkt, &orig_len, &rtx_ssrc, &rtx_pt)) {
-          // Fixed 12-byte RTP header for now; variable-header RTX is a later PR.
-          if (orig_len < 12) {
-            continue;
-          }
-
-          sfu_packet_t *rtx_enc = sfu_packet_pool_alloc(w->pp);
-          if (!rtx_enc) {
-            continue;
-          }
-
-          int total = (int)orig_len + 2;
-          if (total > (int)rtx_enc->cap) {
-            sfu_worker_release_packet(w->pp, &w->release_to_dispatcher, rtx_enc);
-            continue;
-          }
-
-          int rtp_header_len = 12;
-          memcpy(rtx_enc->data, orig_pkt, rtp_header_len);
-
-          rtx_enc->data[1] = (rtx_enc->data[1] & 0x80) | (rtx_pt & 0x7F);
-
-          uint16_t next_rtx_seq = __atomic_fetch_add(&sender_session->rtx_cache->next_rtx_seq, 1, __ATOMIC_RELAXED);
-          sfu_write_be16(rtx_enc->data + 2, next_rtx_seq);
-          sfu_write_be32(rtx_enc->data + 8, rtx_ssrc);
-
-          sfu_write_be16(rtx_enc->data + rtp_header_len, lost_seq);
-          memcpy(rtx_enc->data + rtp_header_len + 2, orig_pkt + rtp_header_len, orig_len - (uint32_t)rtp_header_len);
-
-          int rtx_enc_len = total;
-          if (sfu_srtp_protect_rtp(&sender_session->srtp, rtx_enc->data, &rtx_enc_len, rtx_enc->cap)) {
-            rtx_enc->len = (uint32_t)rtx_enc_len;
-            sfu_ring_queue_send_zc(&w->send_ring, rtx_enc, (const struct sockaddr *)&sender_session->cold->addr, sender_session->cold->addr_len);
-          }
-          sfu_worker_release_packet(w->pp, &w->release_to_dispatcher, rtx_enc);
-        } else {
-          unrecoverable_loss = true;
-        }
-      }
-      if (unrecoverable_loss) {
-        // Throttle PLIs to prevent flooding the publisher (e.g., max 1 per second)
-        int64_t now = sfu_now_ms();
-        if (now - sender_session->last_pli_time > 1000) {
-          sender_session->last_pli_time = now;
-          sfu_session_request_keyframe(w, sender_session, false);  // false = PLI
-        }
-      }
-
-      sfu_worker_release_packet(w->pp, &w->release_to_dispatcher, pkt);
-      return;
-    }
+  if (is_rtcp) {
+    sfu_worker_handle_rtcp(w, sender_session, pkt);
+    return;
   }
 
   bool is_vp9 = false;

--- a/src/util/metrics.c
+++ b/src/util/metrics.c
@@ -14,6 +14,14 @@
 static const char *const k_metric_names[] = {
     "msg_trunc_drop",
     "json_reject",
+    /* Phase 2 worker protocol integration counters. */
+    "rtcp_compound_malformed",
+    "rtcp_member_unknown",
+    "rtcp_twcc_bad",
+    "rtcp_nack_bad",
+    "rtcp_pli_bad",
+    "rtcp_nack_dropped",
+    "rtx_build_fail",
 };
 
 enum { SFU_METRIC_COUNT = sizeof(k_metric_names) / sizeof(k_metric_names[0]) };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -82,3 +82,11 @@ add_executable(test_rtx_build test_rtx_build.c)
 target_link_libraries(test_rtx_build PRIVATE sfu_core)
 add_test(NAME rtx_build COMMAND test_rtx_build)
 
+add_executable(test_nack_parser test_nack_parser.c)
+target_link_libraries(test_nack_parser PRIVATE sfu_core)
+add_test(NAME nack_parser COMMAND test_nack_parser)
+
+add_executable(test_worker_protocol test_worker_protocol.c)
+target_link_libraries(test_worker_protocol PRIVATE sfu_core)
+add_test(NAME worker_protocol COMMAND test_worker_protocol)
+

--- a/tests/test_metrics.c
+++ b/tests/test_metrics.c
@@ -76,7 +76,11 @@ static void test_snapshot_format(void) {
     p = nl + 1;
     lines++;
   }
-  EXPECT(lines == 2);
+  EXPECT(lines >= 2); /* registry grows as new counters are registered */
+
+  /* New counters render too. */
+  EXPECT(strstr(buf, "rtcp_compound_malformed 0\n") != NULL);
+  EXPECT(strstr(buf, "rtx_build_fail 0\n") != NULL);
 
   /* Truncation: tiny buffer still NUL-terminated; return is full length. */
   char tiny[8];

--- a/tests/test_nack_parser.c
+++ b/tests/test_nack_parser.c
@@ -1,0 +1,129 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "rtp/rtx.h"
+#include "util/netbytes.h"
+
+/* Build a NACK member: V=2, FMT=1, PT=205, sender SSRC, media SSRC, then
+ * pid/blp FCI entries. len_word is total 32-bit words minus one. */
+static size_t build_nack(uint8_t *buf, uint32_t media_ssrc, const uint16_t *fci, size_t fci_words) {
+  size_t fci_bytes = fci_words * 2;
+  size_t total = 12 + fci_bytes;
+  buf[0] = 0x80 | 1; /* V=2, FMT=1 */
+  buf[1] = 205;
+  sfu_write_be16(buf + 2, (uint16_t)(total / 4 - 1));
+  sfu_write_be32(buf + 4, 0xdeadbeefu);
+  sfu_write_be32(buf + 8, media_ssrc);
+  for (size_t i = 0; i < fci_words; i++) {
+    sfu_write_be16(buf + 12 + i * 2, fci[i]);
+  }
+  return total;
+}
+
+static void test_valid_single_block(void) {
+  uint8_t buf[64];
+  uint16_t fci[] = {100, 0x0005}; /* pid=100, blp bits 0 and 2 -> 101, 103 */
+  size_t len = build_nack(buf, 0x11223344u, fci, 2);
+
+  sfu_nack_parser_t p;
+  assert(sfu_nack_parser_init(&p, buf, len));
+  assert(sfu_nack_parser_media_ssrc(&p) == 0x11223344u);
+
+  uint16_t seq = 0;
+  assert(sfu_nack_parser_next(&p, &seq) && seq == 100);
+  assert(sfu_nack_parser_next(&p, &seq) && seq == 101);
+  assert(sfu_nack_parser_next(&p, &seq) && seq == 103);
+  assert(!sfu_nack_parser_next(&p, &seq));
+}
+
+static void test_valid_multi_block(void) {
+  uint8_t buf[64];
+  uint16_t fci[] = {50, 0x0001, 200, 0x0000}; /* 50, 51 ; 200 */
+  size_t len = build_nack(buf, 7u, fci, 4);
+
+  sfu_nack_parser_t p;
+  assert(sfu_nack_parser_init(&p, buf, len));
+
+  uint16_t seq = 0;
+  assert(sfu_nack_parser_next(&p, &seq) && seq == 50);
+  assert(sfu_nack_parser_next(&p, &seq) && seq == 51);
+  assert(sfu_nack_parser_next(&p, &seq) && seq == 200);
+  assert(!sfu_nack_parser_next(&p, &seq));
+}
+
+static void test_exact_member_bounds(void) {
+  /* Parser must stop at the member end even if a live buffer continues. */
+  uint8_t storage[64];
+  uint16_t fci[] = {300, 0x0000};
+  size_t len = build_nack(storage, 1u, fci, 2);
+  memset(storage + len, 0xff, sizeof(storage) - len);
+
+  sfu_nack_parser_t p;
+  assert(sfu_nack_parser_init(&p, storage, len));
+  uint16_t seq = 0;
+  assert(sfu_nack_parser_next(&p, &seq) && seq == 300);
+  assert(!sfu_nack_parser_next(&p, &seq));
+}
+
+static void test_rejects(void) {
+  uint8_t buf[64];
+  uint16_t fci[] = {100, 0x0000};
+  size_t len = build_nack(buf, 1u, fci, 2);
+  sfu_nack_parser_t p;
+
+  /* Wrong PT (206 = PSFB). */
+  uint8_t saved_pt = buf[1];
+  buf[1] = 206;
+  assert(!sfu_nack_parser_init(&p, buf, len));
+  buf[1] = saved_pt;
+
+  /* Wrong FMT (15 = TWCC, not generic NACK). */
+  uint8_t saved_b0 = buf[0];
+  buf[0] = 0x80 | 15;
+  assert(!sfu_nack_parser_init(&p, buf, len));
+  buf[0] = saved_b0;
+
+  /* Wrong RTP version. */
+  buf[0] = 0x40 | 1;
+  assert(!sfu_nack_parser_init(&p, buf, len));
+  buf[0] = saved_b0;
+
+  /* Too short: header + SSRCs but no FCI block. */
+  assert(!sfu_nack_parser_init(&p, buf, 12));
+  assert(!sfu_nack_parser_init(&p, buf, 8));
+  assert(!sfu_nack_parser_init(&p, NULL, len));
+
+  /* Failed init leaves the parser inert. */
+  assert(!sfu_nack_parser_next(&p, &(uint16_t){0}));
+}
+
+static void test_fci_multiple_of_four(void) {
+  /* Member with an FCI of 6 bytes (2 mod 4) is rejected even though the
+   * declared RTCP length word covers it. */
+  uint8_t buf[64];
+  uint16_t fci[] = {100, 0x0000, 200};
+  size_t len = build_nack(buf, 1u, fci, 3); /* 12 + 6 = 18 bytes */
+  sfu_nack_parser_t p;
+  assert(!sfu_nack_parser_init(&p, buf, len));
+
+  /* FCI of exactly 4 bytes is the minimal valid member. */
+  uint16_t fci_ok[] = {100, 0x0000};
+  len = build_nack(buf, 1u, fci_ok, 2);
+  assert(sfu_nack_parser_init(&p, buf, len));
+  uint16_t seq = 0;
+  assert(sfu_nack_parser_next(&p, &seq) && seq == 100);
+  assert(!sfu_nack_parser_next(&p, &seq));
+}
+
+int main(void) {
+  test_valid_single_block();
+  test_valid_multi_block();
+  test_exact_member_bounds();
+  test_rejects();
+  test_fci_multiple_of_four();
+  printf("test_nack_parser: OK\n");
+  return 0;
+}

--- a/tests/test_worker_protocol.c
+++ b/tests/test_worker_protocol.c
@@ -1,0 +1,373 @@
+/*
+ * Phase 2 worker protocol integration tests.
+ *
+ * Exercises sfu_room_forward_packet's compound-RTCP dispatch end to end:
+ * plaintext feedback is SRTCP-protected through a real SRTP context, fed
+ * through the worker ingress path, and the resulting NACK/PLI effects are
+ * observed via counters, cache state and throttling. The io_uring send ring
+ * is left zeroed so queued sends fail harmlessly; packet ownership is
+ * verified through the pool release path instead.
+ */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "memory/packet_pool.h"
+#include "net/io_uring.h"
+#include "peer/session.h"
+#include "util/alloc.h"
+#include "rtp/rtx.h"
+#include "runtime/worker.h"
+#include "sfu/datadef.h"
+#include "transport/srtp/srtp.h"
+#include "util/metrics.h"
+#include "util/netbytes.h"
+
+#define POOL_CAPACITY 64
+#define RTP_PT 96
+#define RTX_PT 97
+#define MEDIA_SSRC 0x0a0b0c0du
+#define RTX_SSRC 0x01020304u
+#define SFU_KF_SENDER_SSRC 1u /* hardcoded in sfu_session_request_keyframe */
+
+typedef struct {
+  sfu_worker_t w;
+  sfu_packet_pool_t pp;
+  sfu_session_table_t sessions;
+  sfu_dtls_ctx_t dtls_ctx; /* session creation needs an SSL_CTX; never used */
+  sfu_srtp_ctx_t srtp;     /* single ctx: loopback protect/unprotect */
+  sfu_rtx_cache_t *cache;
+  sfu_peer_session_t *session;
+  int send_fds[2]; /* pipe standing in for the io_uring send fd */
+} fixture_t;
+
+static void build_rtp_video(uint8_t *buf, uint16_t seq, size_t payload_len, size_t *out_len) {
+  buf[0] = 0x80;
+  buf[1] = RTP_PT;
+  sfu_write_be16(buf + 2, seq);
+  sfu_write_be32(buf + 4, 0x11223344u);
+  sfu_write_be32(buf + 8, MEDIA_SSRC);
+  memset(buf + 12, 0xab, payload_len);
+  *out_len = 12 + payload_len;
+}
+
+static size_t rtcp_member_header(uint8_t *buf, uint8_t fmt, uint8_t pt, uint32_t sender_ssrc, size_t body_len) {
+  size_t total = 8 + body_len;
+  assert(total % 4 == 0);
+  buf[0] = 0x80 | (fmt & 0x1F);
+  buf[1] = pt;
+  sfu_write_be16(buf + 2, (uint16_t)(total / 4 - 1));
+  sfu_write_be32(buf + 4, sender_ssrc);
+  return total;
+}
+
+static size_t build_nack(uint8_t *buf, const uint16_t *fci, size_t fci_halfwords) {
+  size_t total = rtcp_member_header(buf, 1, 205, MEDIA_SSRC, 4 + fci_halfwords * 2);
+  sfu_write_be32(buf + 8, MEDIA_SSRC);
+  for (size_t i = 0; i < fci_halfwords; i++) {
+    sfu_write_be16(buf + 12 + i * 2, fci[i]);
+  }
+  return total;
+}
+
+static size_t build_pli(uint8_t *buf) {
+  size_t total = rtcp_member_header(buf, 1, 206, MEDIA_SSRC, 4);
+  sfu_write_be32(buf + 8, MEDIA_SSRC);
+  return total;
+}
+
+static size_t build_fir(uint8_t *buf) {
+  size_t total = rtcp_member_header(buf, 4, 206, MEDIA_SSRC, 12);
+  sfu_write_be32(buf + 8, MEDIA_SSRC);
+  sfu_write_be32(buf + 12, MEDIA_SSRC); /* FCI entry: target SSRC */
+  buf[16] = 7;                          /* seq nr */
+  buf[17] = buf[18] = buf[19] = 0;      /* reserved */
+  return total;
+}
+
+/* Feed one plaintext RTCP compound through the ingress path. */
+static void feed_rtcp(fixture_t *f, const uint8_t *plain, size_t plain_len) {
+  uint8_t wire[2048];
+  memcpy(wire, plain, plain_len);
+  int wire_len = (int)plain_len;
+  bool ok = sfu_srtp_protect_rtcp(&f->srtp, wire, &wire_len, sizeof(wire));
+  assert(ok);
+
+  sfu_packet_t *pkt = sfu_packet_pool_alloc(&f->pp);
+  assert(pkt != NULL);
+  assert((size_t)wire_len <= pkt->cap);
+  memcpy(pkt->data, wire, (size_t)wire_len);
+  pkt->len = (uint32_t)wire_len;
+  pkt->peer_addr = f->session->cold->addr;
+  pkt->peer_addr_len = f->session->cold->addr_len;
+
+  sfu_room_forward_packet(&f->w, pkt);
+}
+
+/* Count packets currently held by the pool (capacity minus free slots). */
+static uint32_t pool_free_count(sfu_packet_pool_t *pp) {
+  uint32_t n = 0;
+  sfu_packet_t *tmp[POOL_CAPACITY];
+  for (;;) {
+    sfu_packet_t *p = sfu_packet_pool_alloc(pp);
+    if (!p || n >= POOL_CAPACITY) {
+      break;
+    }
+    tmp[n++] = p;
+  }
+  for (uint32_t i = 0; i < n; i++) {
+    sfu_worker_release_packet(pp, NULL, tmp[i]);
+  }
+  return n;
+}
+
+static void fixture_init(fixture_t *f) {
+  memset(f, 0, sizeof(*f));
+  assert(sfu_srtp_global_init() == 0);
+  assert(sfu_packet_pool_init(&f->pp, POOL_CAPACITY, 2048) == 0);
+  f->dtls_ctx.ssl_ctx = SSL_CTX_new(TLS_method());
+  assert(f->dtls_ctx.ssl_ctx != NULL);
+  assert(sfu_session_table_init(&f->sessions, &f->dtls_ctx) == 0);
+  sfu_metrics_init();
+
+  uint8_t key_material[SFU_SRTP_KEY_MATERIAL_LEN];
+  for (size_t i = 0; i < sizeof(key_material); i++) {
+    key_material[i] = (uint8_t)(i * 7 + 1);
+  }
+  /* Default profile (AES128_CM_SHA1_80). Loopback: mirror the client half of
+   * the keying material into the server half so outbound (client, since
+   * is_server=false) and inbound (server) derive identical session keys. */
+  memcpy(key_material + 16, key_material, 16);
+  memcpy(key_material + 46, key_material + 32, 14);
+  assert(sfu_srtp_ctx_init_from_dtls(&f->srtp, key_material, 0x0001, false) == 0);
+
+  struct sockaddr_in addr = {0};
+  addr.sin_family = AF_INET;
+  addr.sin_port = htons(5000);
+  addr.sin_addr.s_addr = htonl(0x7f000001u);
+
+  f->session = sfu_session_table_get_or_create(&f->sessions, (const struct sockaddr_storage *)&addr, sizeof(addr));
+  assert(f->session != NULL);
+  memcpy(&f->session->srtp, &f->srtp, sizeof(f->srtp));
+  f->session->state = SFU_SESSION_ESTABLISHED;
+  f->session->worker_id = 0;
+  /* The worker forwards RTX to a zeroed io_uring send ring; keeps the test
+   * single-threaded and out of the kernel. The session's gcc/twcc/scheduler
+   * sub-allocations stay unused (TWCC members are not exercised here; the
+   * TWCC parser already has dedicated protocol tests). */
+  SFU_FREE(f->session->gcc_ctx);
+  f->session->gcc_ctx = NULL;
+  SFU_FREE(f->session->twcc_history);
+  f->session->twcc_history = NULL;
+  SFU_FREE(f->session->scheduler);
+  f->session->scheduler = NULL;
+
+  f->cache = (sfu_rtx_cache_t *)SFU_CALLOC(1, sizeof(sfu_rtx_cache_t));
+  assert(f->cache != NULL);
+  assert(sfu_rtx_cache_init(f->cache) == 0);
+  f->session->rtx_cache = f->cache;
+
+  f->w.pp = &f->pp;
+  f->w.sessions = &f->sessions;
+  f->w.worker_index = 0;
+  /* Small real send ring over a pipe fd: queueing RTX/keyframe sends stays
+   * in-process and never submits, so nothing reaches the kernel. */
+  assert(pipe(f->send_fds) == 0);
+  assert(sfu_ring_init(&f->w.send_ring, f->send_fds[1], 8, 16, 0, 0, -1, false) == 0);
+}
+
+static void fixture_destroy(fixture_t *f) {
+  sfu_ring_destroy(&f->w.send_ring);
+  close(f->send_fds[0]);
+  close(f->send_fds[1]);
+  sfu_rtx_cache_destroy(f->cache);
+  SFU_FREE(f->cache);
+  f->session->rtx_cache = NULL; /* table teardown must not double-free */
+  sfu_session_table_destroy(&f->sessions); /* destroys copied SRTP handles */
+  f->srtp.inbound = NULL;
+  f->srtp.outbound = NULL;
+  sfu_packet_pool_destroy(&f->pp);
+  sfu_srtp_global_deinit();
+  SSL_CTX_free(f->dtls_ctx.ssl_ctx);
+}
+
+/* A valid NACK for a cached packet produces an RTX retransmission attempt,
+ * which consumes the cache's RTX sequence space. */
+static void test_compound_nack_rtx_dispatch(void) {
+  fixture_t f;
+  fixture_init(&f);
+
+  uint8_t pkt_buf[512];
+  size_t pkt_len;
+  build_rtp_video(pkt_buf, 42, 100, &pkt_len);
+  sfu_rtx_cache_put(f.cache, 42, pkt_buf, (uint32_t)pkt_len, RTX_SSRC, RTX_PT);
+  assert(f.cache->next_rtx_seq == 0);
+
+  uint8_t nack[64];
+  size_t nack_len = build_nack(nack, (uint16_t[]){42, 0x0000}, 2);
+  feed_rtcp(&f, nack, nack_len);
+
+  assert(f.cache->next_rtx_seq == 1);
+  assert(sfu_metric_get("rtcp_compound_malformed") == 0);
+  assert(sfu_metric_get("rtcp_nack_bad") == 0);
+  fixture_destroy(&f);
+}
+
+/* NACK + PLI in one compound: both members are dispatched (the old
+ * first-header-only path would have dropped the PLI on the floor). */
+static void test_compound_nack_then_pli(void) {
+  fixture_t f;
+  fixture_init(&f);
+
+  uint8_t compound[128];
+  size_t nack_len = build_nack(compound, (uint16_t[]){4242, 0x0000}, 2); /* not cached */
+  size_t pli_len = build_pli(compound + nack_len);
+  feed_rtcp(&f, compound, nack_len + pli_len);
+
+  /* NACK cache miss marks unrecoverable loss -> throttled keyframe request;
+   * the PLI member then finds last_pli_time already set and is a no-op. Both
+   * members parsed cleanly, so nothing was flagged bad or malformed. */
+  assert(f.session->last_pli_time != 0);
+  assert(sfu_metric_get("rtcp_compound_malformed") == 0);
+  assert(sfu_metric_get("rtcp_nack_bad") == 0);
+  assert(sfu_metric_get("rtcp_pli_bad") == 0);
+  fixture_destroy(&f);
+}
+
+/* PLI then NACK: the reverse order exercises PLI first. */
+static void test_compound_pli_then_nack(void) {
+  fixture_t f;
+  fixture_init(&f);
+
+  uint8_t pkt_buf[512];
+  size_t pkt_len;
+  build_rtp_video(pkt_buf, 7, 60, &pkt_len);
+  sfu_rtx_cache_put(f.cache, 7, pkt_buf, (uint32_t)pkt_len, RTX_SSRC, RTX_PT);
+
+  uint8_t compound[128];
+  size_t pli_len = build_pli(compound);
+  size_t nack_len = build_nack(compound + pli_len, (uint16_t[]){7, 0x0000}, 2);
+  feed_rtcp(&f, compound, pli_len + nack_len);
+
+  assert(f.session->last_pli_time != 0); /* PLI dispatched */
+  assert(f.cache->next_rtx_seq == 1);    /* NACK dispatched and serviced */
+  fixture_destroy(&f);
+}
+
+/* A malformed trailing member drops the remainder but keeps the members
+ * parsed before it, and bumps rtcp_compound_malformed. */
+static void test_malformed_tail_drops_remainder(void) {
+  fixture_t f;
+  fixture_init(&f);
+
+  uint8_t pkt_buf[512];
+  size_t pkt_len;
+  build_rtp_video(pkt_buf, 9, 60, &pkt_len);
+  sfu_rtx_cache_put(f.cache, 9, pkt_buf, (uint32_t)pkt_len, RTX_SSRC, RTX_PT);
+
+  uint8_t compound[128];
+  size_t nack_len = build_nack(compound, (uint16_t[]){9, 0x0000}, 2);
+  /* Bogus member: version 3 -> iterator flags malformed and stops. */
+  compound[nack_len] = 0xC1;
+  compound[nack_len + 1] = 206;
+  sfu_write_be16(compound + nack_len + 2, 2);
+  memset(compound + nack_len + 4, 0, 8);
+  feed_rtcp(&f, compound, nack_len + 12);
+
+  assert(f.cache->next_rtx_seq == 1); /* NACK before the bad member ran */
+  assert(sfu_metric_get("rtcp_compound_malformed") == 1);
+  fixture_destroy(&f);
+}
+
+/* FCI whose length is not a multiple of 4 is rejected before iteration. */
+static void test_bad_nack_fci(void) {
+  fixture_t f;
+  fixture_init(&f);
+
+  uint8_t nack[64];
+  uint16_t fci[] = {42, 0x0000};
+  size_t nack_len = build_nack(nack, fci, 2);
+  nack_len -= 2; /* lie: member ends mid-FCI */
+  /* Fix the length word to match the odd logical size. */
+  sfu_write_be16(nack + 2, 3); /* 16 bytes total -> 14 logical here; parser rejects */
+  feed_rtcp(&f, nack, 14);
+
+  /* The compound iterator rejects the member boundary before dispatching the
+   * NACK parser; the parser's direct odd-FCI rejection is covered separately. */
+  assert(sfu_metric_get("rtcp_compound_malformed") == 1);
+  assert(sfu_metric_get("rtcp_nack_bad") == 0);
+  assert(f.cache->next_rtx_seq == 0);
+  fixture_destroy(&f);
+}
+
+/* Malformed PLI member (wrong body length) bumps rtcp_pli_bad. */
+static void test_bad_pli(void) {
+  fixture_t f;
+  fixture_init(&f);
+
+  uint8_t pli[64];
+  size_t pli_len = rtcp_member_header(pli, 1, 206, MEDIA_SSRC, 8); /* body too long */
+  sfu_write_be32(pli + 8, MEDIA_SSRC);
+  sfu_write_be32(pli + 12, 0);
+  feed_rtcp(&f, pli, pli_len);
+
+  assert(sfu_metric_get("rtcp_pli_bad") == 1);
+  assert(f.session->last_pli_time == 0);
+  fixture_destroy(&f);
+}
+
+/* FIR member is parsed and ignored (no keyframe side effects, no metrics). */
+static void test_fir_ignored(void) {
+  fixture_t f;
+  fixture_init(&f);
+
+  uint8_t fir[64];
+  size_t fir_len = build_fir(fir);
+  feed_rtcp(&f, fir, fir_len);
+
+  assert(sfu_metric_get("rtcp_compound_malformed") == 0);
+  assert(sfu_metric_get("rtcp_pli_bad") == 0);
+  assert(f.session->last_pli_time == 0);
+  fixture_destroy(&f);
+}
+
+/* Every packet fed through the worker must be released exactly once; only
+ * send-completed packets return to the pool (queued ZC sends retain a ref
+ * until their CQE is reaped, and this test never submits). */
+static void test_packet_release_ownership(void) {
+  fixture_t f;
+  fixture_init(&f);
+  assert(pool_free_count(&f.pp) == POOL_CAPACITY);
+
+  /* Malformed compound: dropped without any keyframe/RTX side effects. */
+  uint8_t garbage[16] = {0xC1, 206, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  feed_rtcp(&f, garbage, sizeof(garbage));
+
+  /* PLI triggers one throttled keyframe request: the worker's own PLI build
+   * allocs one packet, queues it (retained ref), and drops its own ref. */
+  uint8_t pli[64];
+  size_t pli_len = build_pli(pli);
+  feed_rtcp(&f, pli, pli_len);
+  feed_rtcp(&f, pli, pli_len); /* throttled: no second keyframe packet */
+
+  assert(pool_free_count(&f.pp) == POOL_CAPACITY - 1);
+  fixture_destroy(&f);
+}
+
+int main(void) {
+  test_compound_nack_rtx_dispatch();
+  test_compound_nack_then_pli();
+  test_compound_pli_then_nack();
+  test_malformed_tail_drops_remainder();
+  test_bad_nack_fci();
+  test_bad_pli();
+  test_fir_ignored();
+  test_packet_release_ownership();
+  printf("test_worker_protocol: OK\n");
+  return 0;
+}


### PR DESCRIPTION
## Summary

Phase 2 of the security remediation series. Builds on PR #70 (runtime safety and protocol foundations) and wires the new primitives into the worker's RTCP hot path.

### Compound RTCP dispatch

- Replace first-header-only RTCP handling with compound iteration via `sfu_rtcp_compound_iter`.
- Every valid member is dispatched independently: TWCC (PT205/FMT15), NACK (PT205/FMT1), PLI (PT206/FMT1), FIR (PT206/FMT4, validated + logged).
- A malformed member drops the remainder of the compound and increments `rtcp_compound_malformed`; previous members still processed.
- Unknown members increment `rtcp_member_unknown`.

### NACK parser rework

- Consumes the exact bounded member view (not the whole datagram).
- Validates V=2, PT=205, FMT=1, minimum length, and FCI multiple-of-4 alignment.
- Alignment-safe big-endian reads via `netbytes.h`.
- Exposes Media SSRC accessor (used in the next phase for publisher routing).
- Per-member request cap (48 distinct sequences) with dedup; overflow counted via `rtcp_nack_dropped`.

### Checked RTX building

- Replaces the inline fixed-12-byte RTX reconstruction with `sfu_rtx_build`.
- Preserves CSRCs and RTP header extensions at the true payload offset.
- Strips original RTP padding; OSN inserted at the true header length.
- Build failures counted via `rtx_build_fail`.

### PLI/FIR handling

- PLI validated via `sfu_rtcp_parse_pli`; keeps the existing 1s-throttled keyframe request path (Media-SSRC publisher routing deferred to the next phase).
- FIR validated via `sfu_rtcp_parse_fir`; logged and ignored.

### VP9 payload offset

- `sfu_rtp_get_payload_offset` now delegates to the strict RTP parser.

## Test plan

- New `test_nack_parser`: exact member bounds, multi-block FCI, alignment validation, PT/FMT/version/length rejects.
- New `test_worker_protocol`: end-to-end through `sfu_room_forward_packet` with a real SRTP loopback and a real io_uring send ring on a pipe fd — compound NACK→PLI and PLI→NACK dispatch, RTX servicing via `next_rtx_seq`, malformed-tail truncation with prior members still dispatched, bad NACK FCI and bad PLI metrics, FIR ignored, packet release ownership accounting.
- Debug: `ctest -E sdp` — **22/22 passed**.
- ASan/UBSan: `ctest -E sdp` — **22/22 passed**.
- `sdp` excluded as pre-existing failure.

## Deferrals (tracked)

- Media-SSRC → publisher routing for NACK/PLI (needs stream-scoped cache and outbound-stream mapping).
- Stream-scoped RTX cache keys.
- Per-source keyframe arbitration.
- Session pinning and immutable receiver snapshots.
- TWCC/GCC rewrite.