### PR TITLE
Add session refcount lifecycle and immutable receiver snapshots

### DIFF
--- a/include/sfu/datadef.h
+++ b/include/sfu/datadef.h
@@ -3,6 +3,7 @@
 
 #include <openssl/ssl.h>
 #include <srtp2/srtp.h>
+#include <stdatomic.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <sys/socket.h>
@@ -38,6 +39,19 @@ typedef enum {
   SFU_SESSION_FAILED,
 } sfu_session_state_t;
 
+/* Session lifecycle (Phase 3, F-01/F-03/F-04 fix):
+ *  - OPEN: published in the session table, lookup-able, accepts work.
+ *  - CLOSING: logically closed. Removed from the table and every hash index;
+ *    no new references can be acquired. Existing refcounted pins keep the
+ *    allocation (and its initialized DTLS/SRTP/RTX state) alive until the
+ *    last sfu_session_release().
+ * `active` stays true through CLOSING so that final teardown always destroys
+ * initialized DTLS/SRTP state regardless of when logical close happened. */
+typedef enum {
+  SFU_SESSION_LIFECYCLE_OPEN = 0,
+  SFU_SESSION_LIFECYCLE_CLOSING,
+} sfu_session_lifecycle_t;
+
 typedef enum {
   SFU_DTLS_FEED_ERROR = -1,
   SFU_DTLS_FEED_IN_PROGRESS = 0,
@@ -50,6 +64,7 @@ typedef struct gcc_bwe_context gcc_bwe_context_t;
 typedef struct sfu_twcc_history sfu_twcc_history_t;
 typedef struct sfu_subscriber_scheduler sfu_subscriber_scheduler_t;
 typedef struct sfu_rtx_cache sfu_rtx_cache_t;
+typedef struct sfu_receiver_snapshot sfu_receiver_snapshot_t;
 
 typedef struct sfu_srtp_ctx {
   srtp_t inbound;
@@ -89,12 +104,42 @@ typedef struct sfu_transceiver {
   sfu_transceiver_metadata_t *metadata;
 } sfu_transceiver_t;
 
-typedef struct sfu_receiver_slot {
-  sfu_transceiver_t *video;
-  sfu_transceiver_t *audio;
+/* One immutable routing entry inside a receiver snapshot. `subscriber` is a
+ * retained (refcounted) destination session; it stays valid for as long as
+ * the entry's snapshot is held, so a worker may use it for the full packet
+ * path without any additional pinning. All remaining fields are value copies
+ * of the publisher's routing metadata taken under the room lock; no mutable
+ * transceiver chains are exposed to readers. */
+typedef struct sfu_receiver_entry {
+  sfu_peer_session_t *subscriber;
+  char subscriber_ufrag[32];
+  uint32_t audio_ssrc;
+  uint32_t video_ssrc;
+  uint32_t video_rtx_ssrc;
   uint32_t mid_audio;
   uint32_t mid_video;
-} sfu_receiver_slot_t;
+  uint8_t video_pt;
+  uint8_t video_rtx_pt;
+  bool has_audio;
+  bool has_video;
+  bool audio_active;
+  bool video_active;
+} sfu_receiver_entry_t;
+
+/* Immutable, refcounted copy-on-write receiver set (F-03/F-04). Readers
+ * acquire-load the session's snapshot pointer, retain it via a CAS on the
+ * refcount (skipping snapshots already draining to zero), traverse entries,
+ * and release. Writers build a fully-populated replacement under the room
+ * lock and release-store it before dropping the old snapshot's writer
+ * reference, so a live pointer can never reference a freed snapshot. The old
+ * snapshot is freed once the last reader lets go. */
+struct sfu_receiver_snapshot {
+  _Atomic uint32_t refcount;
+  uint64_t generation;
+  uint32_t count;
+  uint32_t capacity;
+  sfu_receiver_entry_t entries[];
+};
 
 typedef struct {
   struct sockaddr_storage addr;
@@ -110,7 +155,7 @@ typedef struct sfu_peer_session {
   sfu_subscriber_scheduler_t *scheduler;
   sfu_rtx_cache_t *rtx_cache;
   sfu_peer_session_cold_t *cold;
-  sfu_receiver_slot_t **receivers;
+  _Atomic(sfu_receiver_snapshot_t *) receivers;
   sfu_srtp_ctx_t srtp;
   sfu_transceiver_t uplink_audio;
   sfu_transceiver_t uplink_video;
@@ -121,10 +166,12 @@ typedef struct sfu_peer_session {
   int64_t last_fir_time;
   uint32_t peer_id;
   uint32_t next_remote_mid;
-  uint32_t receiver_capacity;
   int fd;
   uint16_t worker_id;
   _Atomic uint16_t next_twcc_seq;
+  _Atomic uint32_t refcount;
+  _Atomic uint8_t lifecycle;
+  _Atomic bool accepts_work;
   uint8_t state;
   uint8_t target_sid;
   uint8_t target_tid;

--- a/src/peer/session.c
+++ b/src/peer/session.c
@@ -1,4 +1,5 @@
 #include "peer/session.h"
+#include <assert.h>
 #include <string.h>
 #include "congestion/gcc.h"
 #include "congestion/twcc_history.h"
@@ -73,6 +74,60 @@ static uint32_t addr_probe(sfu_hash_slot_t *table, uint32_t cap, uint32_t hash, 
   return for_insert && first_deleted >= 0 ? (uint32_t)first_deleted : SFU_HASH_EMPTY;
 }
 
+/* ---------------------------------------------------------------------------
+ * Receiver snapshot helpers (F-03/F-04)
+ * ------------------------------------------------------------------------- */
+
+/* Lock-free acquire-with-retain: the pointer is only replaced (release
+ * store) while the outgoing snapshot still holds the writer's reference, so
+ * the CAS below can never resurrect a fully-dead snapshot. Memory-reuse ABA
+ * is impossible while the CAS could succeed, because the outgoing snapshot's
+ * writer reference is only dropped after the replacement store. */
+sfu_receiver_snapshot_t *sfu_session_receivers_acquire(const sfu_peer_session_t *s) {
+  sfu_receiver_snapshot_t *snap = atomic_load_explicit(&s->receivers, memory_order_acquire);
+  while (snap) {
+    uint32_t rc = atomic_load_explicit(&snap->refcount, memory_order_relaxed);
+    if (rc == 0) {
+      /* Being torn down by its last releaser; retry for the replacement. */
+      snap = atomic_load_explicit(&s->receivers, memory_order_acquire);
+      continue;
+    }
+    if (atomic_compare_exchange_weak_explicit(&snap->refcount, &rc, rc + 1, memory_order_acquire, memory_order_relaxed)) {
+      return snap;
+    }
+  }
+  return NULL;
+}
+
+void sfu_receiver_snapshot_release(sfu_receiver_snapshot_t *snap) {
+  if (!snap) {
+    return;
+  }
+  uint32_t prev = atomic_fetch_sub_explicit(&snap->refcount, 1, memory_order_acq_rel);
+  assert(prev != 0 && "snapshot refcount underflow");
+  if (prev == 1) {
+    for (uint32_t i = 0; i < snap->count; i++) {
+      sfu_session_release(snap->entries[i].subscriber);
+    }
+    SFU_FREE(snap);
+  }
+}
+
+/* Publishes a fully-built snapshot on the owning session and retires the old
+ * one by dropping the writer's reference. Call with the room lock held. */
+void sfu_session_publish_receivers(sfu_peer_session_t *owner, sfu_receiver_snapshot_t *new_snap) {
+  sfu_receiver_snapshot_t *old = atomic_load_explicit(&owner->receivers, memory_order_acquire);
+  atomic_store_explicit(&owner->receivers, new_snap, memory_order_release);
+  sfu_receiver_snapshot_release(old);
+}
+
+/* ---------------------------------------------------------------------------
+ * Session teardown
+ * ------------------------------------------------------------------------- */
+
+/* Centralized teardown. Runs exactly once, when the last refcount is dropped.
+ * `active` is never cleared before this point (logical close keeps it set),
+ * so initialized DTLS/SRTP state is always destroyed here. */
 static void sfu_session_free_resources(sfu_peer_session_t *s) {
   if (!s) {
     return;
@@ -87,15 +142,11 @@ static void sfu_session_free_resources(sfu_peer_session_t *s) {
     }
   }
 
-  if (s->receivers) {
-    for (uint32_t i = 0; i < s->receiver_capacity; i++) {
-      SFU_FREE(s->receivers[i]);
-      s->receivers[i] = NULL;
-    }
-    SFU_FREE(s->receivers);
-    s->receivers = NULL;
+  sfu_receiver_snapshot_t *snap = atomic_load_explicit(&s->receivers, memory_order_acquire);
+  if (snap) {
+    atomic_store_explicit(&s->receivers, NULL, memory_order_release);
+    sfu_receiver_snapshot_release(snap);
   }
-  s->receiver_capacity = 0;
 
   if (s->rtx_cache) {
     sfu_rtx_cache_destroy(s->rtx_cache);
@@ -120,27 +171,14 @@ static void sfu_session_free_resources(sfu_peer_session_t *s) {
   }
 }
 
-void sfu_session_table_destroy(sfu_session_table_t *t) {
-  pthread_mutex_lock(&t->lock);
-
-  for (uint32_t i = 0; i < t->count; i++) {
-    sfu_peer_session_t *s = t->sessions[i];
-    if (!s) {
-      continue;
-    }
-
+void sfu_session_release(sfu_peer_session_t *s) {
+  if (!s) {
+    return;
+  }
+  if (atomic_fetch_sub_explicit(&s->refcount, 1, memory_order_acq_rel) == 1) {
     sfu_session_free_resources(s);
     SFU_FREE(s);
-    t->sessions[i] = NULL;
   }
-
-  SFU_FREE(t->sessions);
-  t->sessions = NULL;
-  t->count = 0;
-  t->capacity = 0;
-
-  pthread_mutex_unlock(&t->lock);
-  pthread_mutex_destroy(&t->lock);
 }
 
 static bool addr_equal(const struct sockaddr_storage *a, socklen_t a_len, const struct sockaddr_storage *b, socklen_t b_len) {
@@ -150,27 +188,67 @@ static bool addr_equal(const struct sockaddr_storage *a, socklen_t a_len, const 
   return memcmp(a, b, a_len) == 0;
 }
 
+/* Table-lock-held helpers. */
+
+/* Returns the session's member index, or UINT32_MAX if not a live member. */
+static uint32_t table_member_index(const sfu_session_table_t *t, const sfu_peer_session_t *session) {
+  for (uint32_t i = 0; i < t->count; i++) {
+    if (t->sessions[i] == session) {
+      return i;
+    }
+  }
+  return UINT32_MAX;
+}
+
+/* A hash entry is only matched while the member index it references is still
+ * live; the addr/ufrag bytes are compared against the session's cold data. */
 static bool addr_matches_direct(uint32_t idx, void *ctx_) {
   addr_match_ctx_t *ctx = ctx_;
   if (idx >= ctx->t->count) {
     return false;
   }
   sfu_peer_session_t *s = ctx->t->sessions[idx];
-  return s && s->active && s->cold->addr_len == ctx->addr_len && memcmp(&s->cold->addr, ctx->addr, ctx->addr_len) == 0;
+  return s && s->cold->addr_len == ctx->addr_len && memcmp(&s->cold->addr, ctx->addr, ctx->addr_len) == 0;
 }
 
-void sfu_session_table_index_addr(sfu_session_table_t *t, sfu_peer_session_t *session) {
-  uint32_t idx = UINT32_MAX;
-  for (uint32_t i = 0; i < t->count; i++) {
-    if (t->sessions[i] == session) {
-      idx = i;
-      break;
-    }
+static bool ufrag_matches_direct(uint32_t idx, void *ctx_) {
+  ufrag_match_ctx_t *ctx = ctx_;
+  if (idx >= ctx->t->count) {
+    return false;
   }
-  if (idx == UINT32_MAX) {
+  sfu_peer_session_t *s = ctx->t->sessions[idx];
+  return s && s->cold->ufrag[0] != '\0' && strcmp(s->cold->ufrag, ctx->ufrag) == 0;
+}
+
+/* Removes the addr hash entry referencing member index `idx`, if any. */
+static void table_remove_addr_hash(sfu_session_table_t *t, sfu_peer_session_t *s, uint32_t idx) {
+  if (s->cold->addr_len == 0) {
     return;
   }
+  uint32_t hash = fnv1a(&s->cold->addr, s->cold->addr_len);
+  addr_match_ctx_t ctx = {t, &s->cold->addr, s->cold->addr_len};
+  uint32_t slot = addr_probe(t->addr_index, SFU_SESSION_ADDR_HASH_SLOTS, hash, addr_matches_direct, &ctx, false);
+  if (slot != SFU_HASH_EMPTY && t->addr_index[slot].index == idx) {
+    t->addr_index[slot].index = SFU_HASH_DELETED;
+  }
+}
 
+/* Removes the ufrag hash entry referencing member index `idx`, if any. */
+static void table_remove_ufrag_hash(sfu_session_table_t *t, sfu_peer_session_t *s, uint32_t idx) {
+  if (s->cold->ufrag[0] == '\0') {
+    return;
+  }
+  uint32_t hash = fnv1a(s->cold->ufrag, strlen(s->cold->ufrag));
+  ufrag_match_ctx_t ctx = {t, s->cold->ufrag};
+  uint32_t slot = addr_probe(t->ufrag_index, SFU_SESSION_UFRAG_HASH_SLOTS, hash, ufrag_matches_direct, &ctx, false);
+  if (slot != SFU_HASH_EMPTY && t->ufrag_index[slot].index == idx) {
+    t->ufrag_index[slot].index = SFU_HASH_DELETED;
+  }
+}
+
+/* Indexes the session's current address. Call with the table lock held; the
+ * caller must have verified membership. */
+static void table_index_addr_locked(sfu_session_table_t *t, sfu_peer_session_t *session, uint32_t idx) {
   uint32_t hash = fnv1a(&session->cold->addr, session->cold->addr_len);
   addr_match_ctx_t ctx = {t, &session->cold->addr, session->cold->addr_len};
   uint32_t slot = addr_probe(t->addr_index, SFU_SESSION_ADDR_HASH_SLOTS, hash, addr_matches_direct, &ctx, true);
@@ -180,7 +258,30 @@ void sfu_session_table_index_addr(sfu_session_table_t *t, sfu_peer_session_t *se
   }
 }
 
+/* ---------------------------------------------------------------------------
+ * Creation
+ * ------------------------------------------------------------------------- */
+
+/* Frees a session that failed part-way through construction, before it was
+ * ever published. Safe on partially-initialized sessions: DTLS is destroyed
+ * only when its SSL object exists. */
+static void session_destroy_unpublished(sfu_peer_session_t *s) {
+  if (!s) {
+    return;
+  }
+  if (s->cold && s->cold->dtls.ssl) {
+    sfu_dtls_conn_destroy(&s->cold->dtls);
+  }
+  s->active = false; /* suppress the established-state teardown paths */
+  sfu_session_free_resources(s);
+  SFU_FREE(s);
+}
+
 sfu_peer_session_t *sfu_session_table_get_or_create(sfu_session_table_t *t, const struct sockaddr_storage *addr, socklen_t addr_len) {
+  if (!addr || addr_len == 0 || addr_len > sizeof(struct sockaddr_storage)) {
+    return NULL;
+  }
+
   pthread_mutex_lock(&t->lock);
 
   for (uint32_t i = 0; i < t->count; i++) {
@@ -190,46 +291,47 @@ sfu_peer_session_t *sfu_session_table_get_or_create(sfu_session_table_t *t, cons
       continue;
     }
 
-    if (session->active && addr_equal(&session->cold->addr, session->cold->addr_len, addr, addr_len)) {
+    if (addr_equal(&session->cold->addr, session->cold->addr_len, addr, addr_len)) {
+      /* Caller pin: the table slot keeps the session alive under the lock,
+       * so this increment is safe. */
+      atomic_fetch_add_explicit(&session->refcount, 1, memory_order_relaxed);
       pthread_mutex_unlock(&t->lock);
       return session;
     }
   }
 
-  uint32_t index;
-
-  if (t->count < t->capacity) {
-    index = t->count++;
-    t->sessions[index] = SFU_CALLOC(1, sizeof(sfu_peer_session_t));
-    if (!t->sessions[index]) {
-      t->count--;
+  /* First NULL hole wins; extend count only when there is no hole. */
+  uint32_t index = UINT32_MAX;
+  for (uint32_t i = 0; i < t->count; i++) {
+    if (!t->sessions[i]) {
+      index = i;
+      break;
+    }
+  }
+  if (index == UINT32_MAX) {
+    if (t->count >= t->capacity) {
+      SFU_LOG_WARN("session table full (%u), rejecting new peer", t->capacity);
       pthread_mutex_unlock(&t->lock);
       return NULL;
     }
-  } else {
-    SFU_LOG_WARN("session table full (%u), rejecting new peer", t->capacity);
+    index = t->count++;
+  }
+
+  sfu_peer_session_t *s = SFU_CALLOC(1, sizeof(sfu_peer_session_t));
+  if (!s) {
+    if (index + 1 == t->count) {
+      t->count--;
+    }
     pthread_mutex_unlock(&t->lock);
     return NULL;
   }
-
-  sfu_peer_session_t *s = t->sessions[index];
-
-  memset(s, 0, sizeof(*s));
 
   s->cold = SFU_CALLOC(1, sizeof(sfu_peer_session_cold_t));
   if (!s->cold) {
     SFU_FREE(s);
-    t->sessions[index] = NULL;
-    t->count--;
-    pthread_mutex_unlock(&t->lock);
-    return NULL;
-  }
-
-  if (!addr || addr_len > sizeof(s->cold->addr)) {
-    SFU_FREE(s->cold);
-    SFU_FREE(s);
-    t->sessions[index] = NULL;
-    t->count--;
+    if (index + 1 == t->count) {
+      t->count--;
+    }
     pthread_mutex_unlock(&t->lock);
     return NULL;
   }
@@ -248,12 +350,13 @@ sfu_peer_session_t *sfu_session_table_get_or_create(sfu_session_table_t *t, cons
   s->uplink_video.owner = s;
   s->screen.owner = s;
 
-  s->receiver_capacity = 0;
-  s->receivers = NULL;
+  atomic_store_explicit(&s->receivers, NULL, memory_order_relaxed);
 
   s->next_remote_mid = 2;
 
-  sfu_session_table_index_addr(t, s);
+  /* All fallible initialization happens BEFORE the session is published into
+   * the table or any hash, so a construction failure leaves no observable
+   * trace (no slot, no hash entry, no way for another thread to find it). */
 
   s->gcc_ctx = SFU_CALLOC(1, sizeof(gcc_bwe_context_t));
   if (s->gcc_ctx) {
@@ -261,6 +364,9 @@ sfu_peer_session_t *sfu_session_table_get_or_create(sfu_session_table_t *t, cons
   }
 
   s->twcc_history = SFU_CALLOC(1, sizeof(sfu_twcc_history_t));
+  if (s->twcc_history) {
+    sfu_twcc_history_init(s->twcc_history);
+  }
 
   s->scheduler = SFU_CALLOC(1, sizeof(sfu_subscriber_scheduler_t));
   if (s->scheduler) {
@@ -276,64 +382,57 @@ sfu_peer_session_t *sfu_session_table_get_or_create(sfu_session_table_t *t, cons
   }
   if (!s->rtx_cache) {
     SFU_LOG_ERROR("failed to init RTX cache for new peer session");
-
-    sfu_session_free_resources(s);
-    SFU_FREE(s);
-    t->sessions[index] = NULL;
-
+    session_destroy_unpublished(s);
     if (index + 1 == t->count) {
       t->count--;
     }
-
     pthread_mutex_unlock(&t->lock);
     return NULL;
   }
 
   if (sfu_dtls_conn_init(&s->cold->dtls, t->dtls_ctx) != 0) {
     SFU_LOG_ERROR("failed to init DTLS connection for new peer session");
-
-    sfu_session_free_resources(s);
-    SFU_FREE(s);
-    t->sessions[index] = NULL;
-
+    session_destroy_unpublished(s);
     if (index + 1 == t->count) {
       t->count--;
     }
-
     pthread_mutex_unlock(&t->lock);
     return NULL;
   }
+
+  /* Publish: table ref = 1, caller pin = 1, OPEN and accepting work. */
+  atomic_store_explicit(&s->refcount, 2, memory_order_relaxed);
+  atomic_store_explicit(&s->lifecycle, SFU_SESSION_LIFECYCLE_OPEN, memory_order_relaxed);
+  atomic_store_explicit(&s->accepts_work, true, memory_order_relaxed);
+
+  t->sessions[index] = s;
+  table_index_addr_locked(t, s, index);
 
   pthread_mutex_unlock(&t->lock);
   return s;
 }
 
-static bool addr_matches(uint32_t idx, void *ctx_) {
-  addr_match_ctx_t *ctx = ctx_;
-  if (idx >= ctx->t->count) {
-    return false;
-  }
-  sfu_peer_session_t *s = ctx->t->sessions[idx];
-  return s && s->active && s->cold->addr_len == ctx->addr_len && memcmp(&s->cold->addr, ctx->addr, ctx->addr_len) == 0;
-}
+/* ---------------------------------------------------------------------------
+ * Lookups (return a caller pin)
+ * ------------------------------------------------------------------------- */
 
 sfu_peer_session_t *sfu_session_table_find(sfu_session_table_t *t, const struct sockaddr_storage *addr, socklen_t addr_len) {
+  if (!addr || addr_len == 0) {
+    return NULL;
+  }
   uint32_t hash = fnv1a(addr, addr_len);
   addr_match_ctx_t ctx = {t, addr, addr_len};
   pthread_mutex_lock(&t->lock);
-  uint32_t slot = addr_probe(t->addr_index, SFU_SESSION_ADDR_HASH_SLOTS, hash, addr_matches, &ctx, false);
-  sfu_peer_session_t *result = (slot != SFU_HASH_EMPTY && t->addr_index[slot].index != SFU_HASH_EMPTY) ? t->sessions[t->addr_index[slot].index] : NULL;
+  uint32_t slot = addr_probe(t->addr_index, SFU_SESSION_ADDR_HASH_SLOTS, hash, addr_matches_direct, &ctx, false);
+  sfu_peer_session_t *result = NULL;
+  if (slot != SFU_HASH_EMPTY && t->addr_index[slot].index != SFU_HASH_EMPTY && t->addr_index[slot].index < t->count) {
+    result = t->sessions[t->addr_index[slot].index];
+    if (result) {
+      atomic_fetch_add_explicit(&result->refcount, 1, memory_order_relaxed);
+    }
+  }
   pthread_mutex_unlock(&t->lock);
   return result;
-}
-
-static bool ufrag_matches(uint32_t idx, void *ctx_) {
-  ufrag_match_ctx_t *ctx = ctx_;
-  if (idx >= ctx->t->count) {
-    return false;
-  }
-  sfu_peer_session_t *s = ctx->t->sessions[idx];
-  return s && s->active && s->cold->ufrag[0] != '\0' && strcmp(s->cold->ufrag, ctx->ufrag) == 0;
 }
 
 sfu_peer_session_t *sfu_session_table_find_by_ufrag(sfu_session_table_t *t, const char *ufrag) {
@@ -345,86 +444,174 @@ sfu_peer_session_t *sfu_session_table_find_by_ufrag(sfu_session_table_t *t, cons
   ufrag_match_ctx_t ctx = {t, ufrag};
 
   pthread_mutex_lock(&t->lock);
-  uint32_t slot = addr_probe(t->ufrag_index, SFU_SESSION_UFRAG_HASH_SLOTS, hash, ufrag_matches, &ctx, false);
-  sfu_peer_session_t *result = (slot != SFU_HASH_EMPTY && t->ufrag_index[slot].index != SFU_HASH_EMPTY) ? t->sessions[t->ufrag_index[slot].index] : NULL;
+  uint32_t slot = addr_probe(t->ufrag_index, SFU_SESSION_UFRAG_HASH_SLOTS, hash, ufrag_matches_direct, &ctx, false);
+  sfu_peer_session_t *result = NULL;
+  if (slot != SFU_HASH_EMPTY && t->ufrag_index[slot].index != SFU_HASH_EMPTY && t->ufrag_index[slot].index < t->count) {
+    result = t->sessions[t->ufrag_index[slot].index];
+    if (result) {
+      atomic_fetch_add_explicit(&result->refcount, 1, memory_order_relaxed);
+    }
+  }
   pthread_mutex_unlock(&t->lock);
   return result;
 }
 
-void sfu_session_table_remove(sfu_session_table_t *t, sfu_peer_session_t *s) {
-  if (s->room) {
-    room_remove_peer((sfu_room_t *)s->room, s);
+/* ---------------------------------------------------------------------------
+ * Close
+ * ------------------------------------------------------------------------- */
+
+bool sfu_session_begin_close(sfu_session_table_t *t, sfu_peer_session_t *s) {
+  if (!t || !s) {
+    return false;
   }
 
   pthread_mutex_lock(&t->lock);
-  if (s->cold->addr_len > 0) {
-    uint32_t hash = fnv1a(&s->cold->addr, s->cold->addr_len);
-    addr_match_ctx_t ctx = {t, &s->cold->addr, s->cold->addr_len};
-    uint32_t slot = addr_probe(t->addr_index, SFU_SESSION_ADDR_HASH_SLOTS, hash, addr_matches_direct, &ctx, false);
-    if (slot != SFU_HASH_EMPTY) {
-      t->addr_index[slot].index = SFU_HASH_DELETED;
-    }
+
+  if (atomic_load_explicit(&s->lifecycle, memory_order_acquire) != SFU_SESSION_LIFECYCLE_OPEN) {
+    /* Already closing/closed: idempotent no-op. The slot and hash entries
+     * were removed by the first close; nothing to do. */
+    pthread_mutex_unlock(&t->lock);
+    return false;
   }
-  if (s->cold->ufrag[0] != '\0') {
-    uint32_t hash = fnv1a(s->cold->ufrag, strlen(s->cold->ufrag));
-    ufrag_match_ctx_t ctx = {t, s->cold->ufrag};
-    uint32_t slot = addr_probe(t->ufrag_index, SFU_SESSION_UFRAG_HASH_SLOTS, hash, ufrag_matches, &ctx, false);
-    if (slot != SFU_HASH_EMPTY) {
-      t->ufrag_index[slot].index = SFU_HASH_DELETED;
-    }
+
+  /* First OPEN -> CLOSING transition. */
+  atomic_store_explicit(&s->lifecycle, SFU_SESSION_LIFECYCLE_CLOSING, memory_order_release);
+  atomic_store_explicit(&s->accepts_work, false, memory_order_release);
+
+  /* Remove ALL hash entries referencing this session's member index (scan by
+   * index, not by any active-state predicate) and clear the table slot. The
+   * slot becomes a reusable hole for the next create. `active` deliberately
+   * stays true so final teardown destroys initialized DTLS/SRTP state. */
+  uint32_t idx = table_member_index(t, s);
+  if (idx != UINT32_MAX) {
+    table_remove_addr_hash(t, s, idx);
+    table_remove_ufrag_hash(t, s, idx);
+    t->sessions[idx] = NULL;
   }
-  if (s->active) {
-    sfu_session_free_resources(s);
-    s->active = false;
-    s->state = SFU_SESSION_FAILED;
-  }
+
   pthread_mutex_unlock(&t->lock);
+
+  /* Detach from the room exactly once, outside the table lock. Lock ordering:
+   * the close path never holds the table lock while taking the room lock, and
+   * room_media_graph never takes the table lock. */
+  sfu_room_t *room = (sfu_room_t *)s->room;
+  if (room) {
+    room_remove_peer(room, s);
+  }
+
+  /* Drop the table's reference; remaining caller/snapshot pins keep the
+   * allocation alive. */
+  sfu_session_release(s);
+  return true;
 }
 
-void sfu_session_table_rebind_addr(sfu_session_table_t *t, sfu_peer_session_t *s, const struct sockaddr_storage *addr, socklen_t addr_len) {
-  if (!addr || addr_len > sizeof(s->cold->addr)) {
-    return;
+void sfu_session_table_remove(sfu_session_table_t *t, sfu_peer_session_t *s) { (void)sfu_session_begin_close(t, s); }
+
+/* ---------------------------------------------------------------------------
+ * Rebind / ufrag indexing (rejected once closing or not a member)
+ * ------------------------------------------------------------------------- */
+
+bool sfu_session_table_rebind_addr(sfu_session_table_t *t, sfu_peer_session_t *s, const struct sockaddr_storage *addr, socklen_t addr_len) {
+  if (!t || !s || !addr || addr_len == 0 || addr_len > sizeof(s->cold->addr)) {
+    return false;
   }
+
   pthread_mutex_lock(&t->lock);
-  if (s->cold->addr_len > 0) {
-    uint32_t hash = fnv1a(&s->cold->addr, s->cold->addr_len);
-    addr_match_ctx_t ctx = {t, &s->cold->addr, s->cold->addr_len};
-    uint32_t slot = addr_probe(t->addr_index, SFU_SESSION_ADDR_HASH_SLOTS, hash, addr_matches_direct, &ctx, false);
-    if (slot != SFU_HASH_EMPTY) {
-      t->addr_index[slot].index = SFU_HASH_DELETED;
-    }
+
+  uint32_t idx = table_member_index(t, s);
+  if (idx == UINT32_MAX || atomic_load_explicit(&s->lifecycle, memory_order_acquire) != SFU_SESSION_LIFECYCLE_OPEN ||
+      !atomic_load_explicit(&s->accepts_work, memory_order_acquire)) {
+    pthread_mutex_unlock(&t->lock);
+    return false;
   }
+
+  table_remove_addr_hash(t, s, idx);
   memcpy(&s->cold->addr, addr, addr_len);
   s->cold->addr_len = addr_len;
-  sfu_session_table_index_addr(t, s);
+  table_index_addr_locked(t, s, idx);
+
   pthread_mutex_unlock(&t->lock);
+  return true;
 }
 
-void sfu_session_table_index_ufrag(sfu_session_table_t *t, sfu_peer_session_t *session) {
+bool sfu_session_table_index_ufrag(sfu_session_table_t *t, sfu_peer_session_t *session) {
+  if (!t || !session || session->cold->ufrag[0] == '\0') {
+    return false;
+  }
+
   pthread_mutex_lock(&t->lock);
 
-  uint32_t idx = UINT32_MAX;
-  for (uint32_t i = 0; i < t->count; i++) {
-    if (t->sessions[i] == session) {
-      idx = i;
-      break;
-    }
-  }
-  if (idx == UINT32_MAX) {
+  uint32_t idx = table_member_index(t, session);
+  if (idx == UINT32_MAX || atomic_load_explicit(&session->lifecycle, memory_order_acquire) != SFU_SESSION_LIFECYCLE_OPEN ||
+      !atomic_load_explicit(&session->accepts_work, memory_order_acquire)) {
     pthread_mutex_unlock(&t->lock);
-    return;
+    return false;
   }
 
   uint32_t hash = fnv1a(session->cold->ufrag, strlen(session->cold->ufrag));
   ufrag_match_ctx_t ctx = {t, session->cold->ufrag};
-  uint32_t slot = addr_probe(t->ufrag_index, SFU_SESSION_UFRAG_HASH_SLOTS, hash, ufrag_matches, &ctx, true);
+  uint32_t slot = addr_probe(t->ufrag_index, SFU_SESSION_UFRAG_HASH_SLOTS, hash, ufrag_matches_direct, &ctx, true);
   if (slot != SFU_HASH_EMPTY) {
     t->ufrag_index[slot].hash = hash;
     t->ufrag_index[slot].index = idx;
   }
 
   pthread_mutex_unlock(&t->lock);
+  return true;
 }
+
+/* ---------------------------------------------------------------------------
+ * Table destroy
+ * ------------------------------------------------------------------------- */
+
+void sfu_session_table_destroy(sfu_session_table_t *t) {
+  /* No concurrent table users may exist here (workers joined, signaling
+   * stopped, all caller pins released); the lock below is defensive. */
+  sfu_peer_session_t **orphans = SFU_CALLOC(t->count ? t->count : 1, sizeof(*orphans));
+  uint32_t orphan_count = 0;
+
+  pthread_mutex_lock(&t->lock);
+
+  for (uint32_t i = 0; i < t->count; i++) {
+    sfu_peer_session_t *s = t->sessions[i];
+    if (!s) {
+      continue;
+    }
+    if (atomic_load_explicit(&s->lifecycle, memory_order_acquire) == SFU_SESSION_LIFECYCLE_OPEN) {
+      atomic_store_explicit(&s->lifecycle, SFU_SESSION_LIFECYCLE_CLOSING, memory_order_release);
+      atomic_store_explicit(&s->accepts_work, false, memory_order_release);
+      table_remove_addr_hash(t, s, i);
+      table_remove_ufrag_hash(t, s, i);
+    }
+    t->sessions[i] = NULL;
+    if (orphans) {
+      orphans[orphan_count++] = s;
+    }
+  }
+
+  pthread_mutex_unlock(&t->lock);
+
+  /* Detach rooms and drop table refs outside the lock. */
+  for (uint32_t i = 0; i < orphan_count; i++) {
+    sfu_room_t *room = (sfu_room_t *)orphans[i]->room;
+    if (room) {
+      room_remove_peer(room, orphans[i]);
+    }
+    sfu_session_release(orphans[i]);
+  }
+  SFU_FREE(orphans);
+
+  SFU_FREE(t->sessions);
+  t->sessions = NULL;
+  t->count = 0;
+  t->capacity = 0;
+
+  pthread_mutex_destroy(&t->lock);
+}
+
+/* ---------------------------------------------------------------------------
+ * Keyframe requests
+ * ------------------------------------------------------------------------- */
 
 void sfu_session_request_keyframe(sfu_worker_t *w, sfu_peer_session_t *publisher, bool use_fir) {
   sfu_packet_t *rtcp_pkt = sfu_packet_pool_alloc(w->pp);

--- a/src/peer/session.h
+++ b/src/peer/session.h
@@ -2,6 +2,7 @@
 #define SFU_PEER_SESSION_H
 
 #include <pthread.h>
+#include <stdatomic.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include "runtime/worker.h"
@@ -9,15 +10,79 @@
 
 typedef struct sfu_worker sfu_worker_t;
 
+/* ---------------------------------------------------------------------------
+ * Session lifetime model (Phase 3 — fixes F-01/F-03/F-04)
+ *
+ * Every sfu_peer_session_t is refcounted:
+ *   - +1 held by the session table from publish until sfu_session_begin_close.
+ *   - +1 per caller pin returned by get_or_create / find / find_by_ufrag.
+ *   - +1 per subscriber entry held by a receiver snapshot (see below).
+ *
+ * Ownership matrix:
+ *   table slot/hash entry  -> 1 ref, dropped in begin_close under table lock
+ *   lookup/create caller   -> 1 ref, must sfu_session_release() exactly once
+ *   snapshot entry         -> 1 ref on the *subscriber*, released with snapshot
+ *   signaling c->session   -> no ref; never dereferenced (borrowed use removed)
+ *
+ * A session pointer obtained from any lookup/create stays valid (allocation
+ * and initialized DTLS/SRTP/RTX state included) until the caller releases it,
+ * even if the session is concurrently closed via sfu_session_begin_close.
+ * Closing only stops NEW references and removes the session from the table,
+ * hashes, and room.
+ * ------------------------------------------------------------------------- */
+
 int sfu_session_table_init(sfu_session_table_t *t, sfu_dtls_ctx_t *dtls_ctx);
+/* Requires that no concurrent table users exist (shutdown quiescence): all
+ * workers joined, signaling stopped, and every caller pin released. Sessions
+ * still OPEN are force-closed (detached from their rooms, table ref dropped),
+ * then table storage is freed. */
 void sfu_session_table_destroy(sfu_session_table_t *t);
+
+/* All lookup/create functions return a caller pin (+1 ref); the caller MUST
+ * sfu_session_release() it exactly once. NULL means not found / not created. */
 sfu_peer_session_t *sfu_session_table_get_or_create(sfu_session_table_t *t, const struct sockaddr_storage *addr, socklen_t addr_len);
 sfu_peer_session_t *sfu_session_table_find(sfu_session_table_t *t, const struct sockaddr_storage *addr, socklen_t addr_len);
 sfu_peer_session_t *sfu_session_table_find_by_ufrag(sfu_session_table_t *t, const char *ufrag);
+
+/* Drops one reference. When the last ref goes away the session's centralized
+ * teardown runs and the allocation is freed. `s` must not be used after. */
+void sfu_session_release(sfu_peer_session_t *s);
+
+/* Acquire load of the work-acceptance flag. False means the session is
+ * closing/closed and must not be given new work. */
+static inline bool sfu_session_accepts_work(const sfu_peer_session_t *s) { return atomic_load_explicit(&s->accepts_work, memory_order_acquire); }
+
+/* Idempotent logical close. The first OPEN->CLOSING transition: flips
+ * accepts_work (release), removes every addr/ufrag hash entry and the table
+ * slot, unlocks, detaches the room exactly once, and drops the table ref.
+ * Returns true for the first (effective) close, false for repeats. The
+ * session allocation and its initialized transport state stay alive until
+ * the remaining refs are released. */
+bool sfu_session_begin_close(sfu_session_table_t *t, sfu_peer_session_t *s);
+
+/* Delegates to sfu_session_begin_close. */
 void sfu_session_table_remove(sfu_session_table_t *t, sfu_peer_session_t *s);
-void sfu_session_table_rebind_addr(sfu_session_table_t *t, sfu_peer_session_t *s, const struct sockaddr_storage *addr, socklen_t addr_len);
-void sfu_session_table_index_ufrag(sfu_session_table_t *t, sfu_peer_session_t *session);
+
+/* Rebinds the transport address. Returns false (no-op) unless the session is
+ * still a live OPEN table member. Old hash entries are removed by member
+ * index before the new address is indexed. */
+bool sfu_session_table_rebind_addr(sfu_session_table_t *t, sfu_peer_session_t *s, const struct sockaddr_storage *addr, socklen_t addr_len);
+
+/* Publishes the session's ufrag into the ufrag hash. Returns false (no-op)
+ * unless the session is still a live OPEN table member. */
+bool sfu_session_table_index_ufrag(sfu_session_table_t *t, sfu_peer_session_t *session);
+
 void sfu_session_request_keyframe(sfu_worker_t *w, sfu_peer_session_t *publisher, bool use_fir);
+
+/* Receiver snapshot access (F-03/F-04). sfu_session_receivers_acquire returns
+ * a retained immutable snapshot (or NULL); traverse ->entries[0..count) freely
+ * — each entry's subscriber is itself retained by the snapshot — then call
+ * sfu_receiver_snapshot_release exactly once. */
+sfu_receiver_snapshot_t *sfu_session_receivers_acquire(const sfu_peer_session_t *s);
+void sfu_receiver_snapshot_release(sfu_receiver_snapshot_t *snap);
+/* Writer-side publish (room lock must be held); declared here so both
+ * room_media_graph.c and tests can use it. Takes ownership of new_snap. */
+void sfu_session_publish_receivers(sfu_peer_session_t *owner, sfu_receiver_snapshot_t *new_snap);
 
 static inline uint8_t sfu_session_get_mapped_pt(const sfu_peer_session_t *session, uint8_t incoming_pt) {
   /* Mask to 7 bits just in case, ensuring we never cause an out-of-bounds read */

--- a/src/pipeline/dispatch.c
+++ b/src/pipeline/dispatch.c
@@ -130,6 +130,8 @@ static void handle_stun(sfu_worker_t *w, sfu_packet_t *pkt) {
 
   if (have_ufrag) {
     if (room) {
+      /* Both lookups return a caller pin (+1 ref) that this function releases
+       * exactly once on every path below. */
       sfu_peer_session_t *session = NULL;
       if (client_ufrag[0] != '\0') {
         session = sfu_session_table_find_by_ufrag(w->sessions, client_ufrag);
@@ -141,8 +143,8 @@ static void handle_stun(sfu_worker_t *w, sfu_packet_t *pkt) {
           if (session->state == SFU_SESSION_ESTABLISHED) {
             SFU_LOG_DEBUG("worker %u: ufrag=%s STUN from alternate candidate %s:%u (session already established at different addr, not rebinding)",
                           w->worker_index, client_ufrag, ip, port);
-          } else {
-            sfu_session_table_rebind_addr(w->sessions, session, &pkt->peer_addr, pkt->peer_addr_len);
+          } else if (!sfu_session_table_rebind_addr(w->sessions, session, &pkt->peer_addr, pkt->peer_addr_len)) {
+            SFU_LOG_DEBUG("worker %u: ufrag=%s rebind rejected (session closing or not a table member)", w->worker_index, client_ufrag);
           }
         }
       } else {
@@ -150,11 +152,16 @@ static void handle_stun(sfu_worker_t *w, sfu_packet_t *pkt) {
       }
       if (!session) {
         SFU_LOG_ERROR("worker %u: could not create/find session for %s:%u to bind room", w->worker_index, ip, port);
+      } else if (!sfu_session_accepts_work(session)) {
+        /* Session is closing/closed: do not bind, index, or mutate it. */
+        SFU_LOG_DEBUG("worker %u: session for ufrag=%s is closing; skipping room bind", w->worker_index, client_ufrag);
       } else {
         if (session->cold->ufrag[0] == '\0') {
           strncpy(session->cold->ufrag, client_ufrag, sizeof(session->cold->ufrag) - 1);
           session->cold->ufrag[sizeof(session->cold->ufrag) - 1] = '\0';
-          sfu_session_table_index_ufrag(w->sessions, session);
+          if (!sfu_session_table_index_ufrag(w->sessions, session)) {
+            SFU_LOG_WARN("worker %u: ufrag index rejected for closing session %s", w->worker_index, client_ufrag);
+          }
         }
 
         if (!session->room) {
@@ -193,6 +200,9 @@ static void handle_stun(sfu_worker_t *w, sfu_packet_t *pkt) {
           session->worker_id = w->worker_index;
         }
       }
+      if (session) {
+        sfu_session_release(session);
+      }
     } else {
       SFU_LOG_DEBUG(
           "worker %u: no room registered yet for ufrag=%s (from %s:%u) -- "
@@ -207,9 +217,16 @@ static void handle_dtls(sfu_worker_t *w, sfu_packet_t *pkt) {
   uint16_t port;
   format_peer_endpoint(&pkt->peer_addr, ip, &port);
 
+  /* Caller pin: released at the end of this handler on every path. */
   sfu_peer_session_t *session = sfu_session_table_get_or_create(w->sessions, &pkt->peer_addr, pkt->peer_addr_len);
   if (!session) {
     SFU_LOG_ERROR("worker %u: CRITICAL! Session table full or rejected registration for %s:%u", w->worker_index, ip, port);
+    return;
+  }
+
+  if (!sfu_session_accepts_work(session)) {
+    SFU_LOG_DEBUG("worker %u: dropping DTLS for closing session %s:%u", w->worker_index, ip, port);
+    sfu_session_release(session);
     return;
   }
 
@@ -252,6 +269,8 @@ static void handle_dtls(sfu_worker_t *w, sfu_packet_t *pkt) {
       SFU_LOG_WARN("worker %u: DTLS handshake failed for peer %s:%u", w->worker_index, ip, port);
       break;
   }
+
+  sfu_session_release(session);
 }
 
 void sfu_dispatch_packet(sfu_worker_t *w, sfu_packet_t *pkt) {

--- a/src/protocol/signaling/sdp.c
+++ b/src/protocol/signaling/sdp.c
@@ -1,4 +1,5 @@
 #include "protocol/signaling/sdp.h"
+#include "peer/session.h"
 #include "util/log.h"
 
 #include <stdio.h>
@@ -256,12 +257,26 @@ int sfu_sdp_build_initial_offer(const char *host, uint16_t port, const char *ufr
   return (int)off;
 }
 
-static inline sfu_receiver_slot_t *sfu_session_receiver(const sfu_peer_session_t *session, uint32_t i) {
-  if (!session->receivers || i >= session->receiver_capacity) {
-    return NULL;
+/* Fills a read-only view of snapshot entry `i`. Returns false when the entry
+ * has no routing state. The caller must hold the snapshot. */
+static bool sfu_sdp_receiver_view(const sfu_receiver_snapshot_t *snap, uint32_t i, sfu_sdp_receiver_view_t *view) {
+  const sfu_receiver_entry_t *e = &snap->entries[i];
+  if (!e->has_audio && !e->has_video) {
+    return false;
   }
-
-  return session->receivers[i];
+  view->audio_ssrc = e->audio_ssrc;
+  view->video_ssrc = e->video_ssrc;
+  view->video_rtx_ssrc = e->video_rtx_ssrc;
+  view->mid_audio = e->mid_audio;
+  view->mid_video = e->mid_video;
+  view->video_pt = e->video_pt;
+  view->video_rtx_pt = e->video_rtx_pt;
+  view->has_audio = e->has_audio;
+  view->has_video = e->has_video;
+  view->audio_active = e->audio_active;
+  view->video_active = e->video_active;
+  snprintf(view->owner_ufrag, sizeof(view->owner_ufrag), "%s", e->subscriber_ufrag);
+  return true;
 }
 
 int sfu_sdp_build_answer(const sfu_peer_session_t *session, const char *offer, size_t offer_len, const char *host, uint16_t port, const char *ufrag,
@@ -270,6 +285,10 @@ int sfu_sdp_build_answer(const sfu_peer_session_t *session, const char *offer, s
   int in_media = 0;
   int saw_media_line = 0;
   int current_media = 0;
+
+  /* Coherent, immutable view of the receiver set for the whole build (F-03). */
+  sfu_receiver_snapshot_t *snap = sfu_session_receivers_acquire(session);
+  uint32_t receiver_count = snap ? snap->count : 0;
 
   uint8_t video_pt = session->uplink_video.payload_type ? session->uplink_video.payload_type : SFU_PT_VP8;
   uint8_t rtx_pt = session->uplink_video.rtx_payload_type ? session->uplink_video.rtx_payload_type : SFU_PT_VP8_RTX;
@@ -301,26 +320,21 @@ int sfu_sdp_build_answer(const sfu_peer_session_t *session, const char *offer, s
       bundle_line[blen] = '\0';
 
       uint32_t tmp_mid = 100;
-      for (uint32_t i = 0; i < session->receiver_capacity; i++) {
-        const sfu_receiver_slot_t *slot = sfu_session_receiver(session, i);
-
-        if (!slot) {
+      for (uint32_t i = 0; i < receiver_count; i++) {
+        sfu_sdp_receiver_view_t slot;
+        if (!sfu_sdp_receiver_view(snap, i, &slot)) {
           continue;
         }
 
-        if (!slot->audio && !slot->video) {
-          continue;
-        }
-
-        if (slot->audio && slot->audio->ssrc != 0) {
+        if (slot.has_audio && slot.audio_ssrc != 0) {
           snprintf(bundle_line + strlen(bundle_line), sizeof(bundle_line) - strlen(bundle_line), " %u", tmp_mid++);
         }
-        if (slot->video && slot->video->ssrc != 0) {
+        if (slot.has_video && slot.video_ssrc != 0) {
           snprintf(bundle_line + strlen(bundle_line), sizeof(bundle_line) - strlen(bundle_line), " %u", tmp_mid++);
         }
       }
       if (append_line(out, out_cap, &off, bundle_line) != 0) {
-        return -1;
+        goto fail;
       }
       continue;
     }
@@ -329,32 +343,32 @@ int sfu_sdp_build_answer(const sfu_peer_session_t *session, const char *offer, s
       char o_line[128];
       int n = snprintf(o_line, sizeof(o_line), "o=- %ld 2 IN IP4 %s", (long)time(NULL), host);
       if (n < 0 || (size_t)n >= sizeof(o_line) || append_line_n(out, out_cap, &off, o_line, (size_t)n) != 0) {
-        return -1;
+        goto fail;
       }
       continue;
     }
 
     if (starts_with(line, len, "a=sendonly")) {
       if (append_line(out, out_cap, &off, "a=recvonly") != 0) {
-        return -1;
+        goto fail;
       }
       continue;
     }
     if (starts_with(line, len, "a=recvonly")) {
       if (append_line(out, out_cap, &off, "a=sendonly") != 0) {
-        return -1;
+        goto fail;
       }
       continue;
     }
     if (starts_with(line, len, "a=sendrecv")) {
       if (append_line(out, out_cap, &off, "a=sendrecv") != 0) {
-        return -1;
+        goto fail;
       }
       continue;
     }
     if (starts_with(line, len, "a=inactive")) {
       if (append_line(out, out_cap, &off, "a=inactive") != 0) {
-        return -1;
+        goto fail;
       }
       continue;
     }
@@ -373,11 +387,11 @@ int sfu_sdp_build_answer(const sfu_peer_session_t *session, const char *offer, s
 
       const char *sp1 = memchr(line, ' ', len);
       if (!sp1) {
-        return -1;
+        goto fail;
       }
       const char *sp2 = memchr(sp1 + 1, ' ', len - (size_t)(sp1 + 1 - line));
       if (!sp2) {
-        return -1;
+        goto fail;
       }
 
       char m_line[256];
@@ -393,14 +407,14 @@ int sfu_sdp_build_answer(const sfu_peer_session_t *session, const char *offer, s
         m_len = snprintf(m_line, sizeof(m_line), "%.*s %u%.*s", (int)(sp1 - line), line, port, (int)(len - (size_t)(sp2 - line)), sp2);
       }
       if (m_len < 0 || (size_t)m_len >= sizeof(m_line) || append_line_n(out, out_cap, &off, m_line, (size_t)m_len) != 0) {
-        return -1;
+        goto fail;
       }
       if (append_media_transport_headers(out, out_cap, &off, host, port, ufrag, pwd, fingerprint) != 0) {
-        return -1;
+        goto fail;
       }
       if (current_media == 2 && video_pt != 0) {
         if (append_video_codec_attributes(out, out_cap, &off, video_pt, rtx_pt) != 0) {
-          return -1;
+          goto fail;
         }
       }
       continue;
@@ -411,7 +425,7 @@ int sfu_sdp_build_answer(const sfu_peer_session_t *session, const char *offer, s
         continue;
       }
       if (append_line_n(out, out_cap, &off, line, len) != 0) {
-        return -1;
+        goto fail;
       }
     } else {
       if (should_skip_line(line, len)) {
@@ -423,60 +437,55 @@ int sfu_sdp_build_answer(const sfu_peer_session_t *session, const char *offer, s
         }
       }
       if (append_line_n(out, out_cap, &off, line, len) != 0) {
-        return -1;
+        goto fail;
       }
     }
   }
 
   if (!saw_media_line) {
     SFU_LOG_WARN("SDP offer had no m= line, cannot build an answer");
-    return -1;
+    goto fail;
   }
 
   /* Generate dedicated media sections for all remote publishers at the end of the SDP */
   uint32_t mid_counter = 100;  // Offset MIDs to prevent clashes with client MIDs
   char buf[256];
 
-  for (uint32_t i = 0; i < session->receiver_capacity; i++) {
-    const sfu_receiver_slot_t *slot = sfu_session_receiver(session, i);
-
-    if (!slot) {
+  for (uint32_t i = 0; i < receiver_count; i++) {
+    sfu_sdp_receiver_view_t slot;
+    if (!sfu_sdp_receiver_view(snap, i, &slot)) {
       continue;
     }
 
-    if (!slot->audio && !slot->video) {
-      continue;
-    }
-
-    if (slot->audio && slot->audio->ssrc != 0) {
+    if (slot.has_audio && slot.audio_ssrc != 0) {
       snprintf(buf, sizeof(buf), "m=audio %u UDP/TLS/RTP/SAVPF 111", port);
       if (append_line(out, out_cap, &off, buf) != 0) {
-        return -1;
+        goto fail;
       }
       if (append_media_transport_headers(out, out_cap, &off, host, port, ufrag, pwd, fingerprint) != 0) {
-        return -1;
+        goto fail;
       }
       if (append_line(out, out_cap, &off, "a=sendonly") != 0) {
-        return -1;
+        goto fail;
       }
       snprintf(buf, sizeof(buf), "a=mid:%u", mid_counter++);
       if (append_line(out, out_cap, &off, buf) != 0) {
-        return -1;
+        goto fail;
       }
       if (append_line(out, out_cap, &off, "a=rtcp-mux") != 0) {
-        return -1;
+        goto fail;
       }
       if (append_line(out, out_cap, &off, "a=rtpmap:111 opus/48000/2") != 0) {
-        return -1;
+        goto fail;
       }
-      if (append_remote_audio_ssrcs(out, out_cap, &off, slot->audio->ssrc, slot->audio->owner->cold->ufrag) != 0) {
-        return -1;
+      if (append_remote_audio_ssrcs(out, out_cap, &off, slot.audio_ssrc, slot.owner_ufrag) != 0) {
+        goto fail;
       }
     }
 
-    if (slot->video && slot->video->ssrc != 0) {
-      uint8_t remote_video_pt = slot->video->payload_type != 0 ? slot->video->payload_type : SFU_PT_VP8;
-      uint8_t remote_rtx_pt = slot->video->rtx_payload_type != 0 ? slot->video->rtx_payload_type : SFU_PT_VP8_RTX;
+    if (slot.has_video && slot.video_ssrc != 0) {
+      uint8_t remote_video_pt = slot.video_pt != 0 ? slot.video_pt : SFU_PT_VP8;
+      uint8_t remote_rtx_pt = slot.video_rtx_pt != 0 ? slot.video_rtx_pt : SFU_PT_VP8_RTX;
 
       if (remote_rtx_pt != 0) {
         snprintf(buf, sizeof(buf), "m=video %u UDP/TLS/RTP/SAVPF %u %u", port, remote_video_pt, remote_rtx_pt);
@@ -484,31 +493,36 @@ int sfu_sdp_build_answer(const sfu_peer_session_t *session, const char *offer, s
         snprintf(buf, sizeof(buf), "m=video %u UDP/TLS/RTP/SAVPF %u", port, remote_video_pt);
       }
       if (append_line(out, out_cap, &off, buf) != 0) {
-        return -1;
+        goto fail;
       }
       if (append_media_transport_headers(out, out_cap, &off, host, port, ufrag, pwd, fingerprint) != 0) {
-        return -1;
+        goto fail;
       }
       if (append_line(out, out_cap, &off, "a=sendonly") != 0) {
-        return -1;
+        goto fail;
       }
       snprintf(buf, sizeof(buf), "a=mid:%u", mid_counter++);
       if (append_line(out, out_cap, &off, buf) != 0) {
-        return -1;
+        goto fail;
       }
       if (append_line(out, out_cap, &off, "a=rtcp-mux") != 0) {
-        return -1;
+        goto fail;
       }
       if (append_video_codec_attributes(out, out_cap, &off, remote_video_pt, remote_rtx_pt) != 0) {
-        return -1;
+        goto fail;
       }
-      if (append_remote_video_ssrcs(out, out_cap, &off, slot->video->ssrc, slot->video->rtx_ssrc, slot->video->owner->cold->ufrag) != 0) {
-        return -1;
+      if (append_remote_video_ssrcs(out, out_cap, &off, slot.video_ssrc, slot.video_rtx_ssrc, slot.owner_ufrag) != 0) {
+        goto fail;
       }
     }
   }
 
+  sfu_receiver_snapshot_release(snap);
   return (int)off;
+
+fail:
+  sfu_receiver_snapshot_release(snap);
+  return -1;
 }
 
 int sfu_sdp_build_offer(const sfu_peer_session_t *session, const char *host, uint16_t port, const char *ufrag, const char *pwd, const char *fingerprint,
@@ -517,42 +531,46 @@ int sfu_sdp_build_offer(const sfu_peer_session_t *session, const char *host, uin
   char buf[512];
   int n;
 
+  /* Coherent, immutable view of the receiver set for the whole build (F-03). */
+  sfu_receiver_snapshot_t *snap = sfu_session_receivers_acquire(session);
+  uint32_t receiver_count = snap ? snap->count : 0;
+
   /* Session-level header. Fresh o= line since there is no inbound offer to mirror. */
   if (append_line(out, out_cap, &off, "v=0") != 0) {
-    return -1;
+    goto fail;
   }
   n = snprintf(buf, sizeof(buf), "o=- %ld 2 IN IP4 %s", (long)time(NULL), host);
   if (n < 0 || (size_t)n >= sizeof(buf) || append_line_n(out, out_cap, &off, buf, (size_t)n) != 0) {
-    return -1;
+    goto fail;
   }
   if (append_line(out, out_cap, &off, "s=-") != 0) {
-    return -1;
+    goto fail;
   }
   if (append_line(out, out_cap, &off, "t=0 0") != 0) {
-    return -1;
+    goto fail;
   }
 
-  SFU_LOG_DEBUG("SDP_BUILD: ufrag=%s receiver_capacity=%u", session->cold->ufrag, session->receiver_capacity);
+  SFU_LOG_DEBUG("SDP_BUILD: ufrag=%s receiver_count=%u", session->cold->ufrag, receiver_count);
 
   char bundle_line[512];
   size_t blen = (size_t)snprintf(bundle_line, sizeof(bundle_line), "a=group:BUNDLE 0 1");
-  for (uint32_t i = 0; i < session->receiver_capacity; i++) {
-    const sfu_receiver_slot_t *slot = sfu_session_receiver(session, i);
-    if (!slot) {
+  for (uint32_t i = 0; i < receiver_count; i++) {
+    sfu_sdp_receiver_view_t slot;
+    if (!sfu_sdp_receiver_view(snap, i, &slot)) {
       continue;
     }
 
-    n = snprintf(bundle_line + blen, sizeof(bundle_line) - blen, " %u %u", slot->mid_audio, slot->mid_video);
+    n = snprintf(bundle_line + blen, sizeof(bundle_line) - blen, " %u %u", slot.mid_audio, slot.mid_video);
     if (n < 0 || (size_t)n >= sizeof(bundle_line) - blen) {
-      return -1;
+      goto fail;
     }
     blen += (size_t)n;
   }
   if (append_line(out, out_cap, &off, bundle_line) != 0) {
-    return -1;
+    goto fail;
   }
   if (append_line(out, out_cap, &off, "a=ice-lite") != 0) {
-    return -1;
+    goto fail;
   }
 
   uint8_t local_video_pt = session->uplink_video.payload_type ? session->uplink_video.payload_type : SFU_PT_VP8;
@@ -560,22 +578,22 @@ int sfu_sdp_build_offer(const sfu_peer_session_t *session, const char *host, uin
 
   n = snprintf(buf, sizeof(buf), "m=audio %u UDP/TLS/RTP/SAVPF 111", port);
   if (n < 0 || (size_t)n >= sizeof(buf) || append_line_n(out, out_cap, &off, buf, (size_t)n) != 0) {
-    return -1;
+    goto fail;
   }
   if (append_media_transport_headers(out, out_cap, &off, host, port, ufrag, pwd, fingerprint) != 0) {
-    return -1;
+    goto fail;
   }
   if (append_line(out, out_cap, &off, "a=recvonly") != 0) {
-    return -1;
+    goto fail;
   }
   if (append_line(out, out_cap, &off, "a=mid:0") != 0) {
-    return -1;
+    goto fail;
   }
   if (append_line(out, out_cap, &off, "a=rtcp-mux") != 0) {
-    return -1;
+    goto fail;
   }
   if (append_line(out, out_cap, &off, "a=rtpmap:111 opus/48000/2") != 0) {
-    return -1;
+    goto fail;
   }
 
   if (local_rtx_pt != 0) {
@@ -584,62 +602,62 @@ int sfu_sdp_build_offer(const sfu_peer_session_t *session, const char *host, uin
     n = snprintf(buf, sizeof(buf), "m=video %u UDP/TLS/RTP/SAVPF %u", port, local_video_pt);
   }
   if (n < 0 || (size_t)n >= sizeof(buf) || append_line_n(out, out_cap, &off, buf, (size_t)n) != 0) {
-    return -1;
+    goto fail;
   }
   if (append_media_transport_headers(out, out_cap, &off, host, port, ufrag, pwd, fingerprint) != 0) {
-    return -1;
+    goto fail;
   }
   if (append_line(out, out_cap, &off, "a=recvonly") != 0) {
-    return -1;
+    goto fail;
   }
   if (append_line(out, out_cap, &off, "a=mid:1") != 0) {
-    return -1;
+    goto fail;
   }
   if (append_line(out, out_cap, &off, "a=rtcp-mux") != 0) {
-    return -1;
+    goto fail;
   }
   if (append_video_codec_attributes(out, out_cap, &off, local_video_pt, local_rtx_pt) != 0) {
-    return -1;
+    goto fail;
   }
 
-  for (uint32_t i = 0; i < session->receiver_capacity; i++) {
-    const sfu_receiver_slot_t *slot = sfu_session_receiver(session, i);
-    if (!slot) {
+  for (uint32_t i = 0; i < receiver_count; i++) {
+    sfu_sdp_receiver_view_t slot;
+    if (!sfu_sdp_receiver_view(snap, i, &slot)) {
       continue;
     }
 
-    bool audio_live = slot->audio && slot->audio->active && slot->audio->ssrc != 0;
-    bool video_live = slot->video && slot->video->active && slot->video->ssrc != 0;
+    bool audio_live = slot.has_audio && slot.audio_active && slot.audio_ssrc != 0;
+    bool video_live = slot.has_video && slot.video_active && slot.video_ssrc != 0;
 
     n = snprintf(buf, sizeof(buf), "m=audio %u UDP/TLS/RTP/SAVPF 111", port);
     if (n < 0 || (size_t)n >= sizeof(buf) || append_line_n(out, out_cap, &off, buf, (size_t)n) != 0) {
-      return -1;
+      goto fail;
     }
     if (append_media_transport_headers(out, out_cap, &off, host, port, ufrag, pwd, fingerprint) != 0) {
-      return -1;
+      goto fail;
     }
     if (append_line(out, out_cap, &off, audio_live ? "a=sendonly" : "a=inactive") != 0) {
-      return -1;
+      goto fail;
     }
-    n = snprintf(buf, sizeof(buf), "a=mid:%u", slot->mid_audio);
+    n = snprintf(buf, sizeof(buf), "a=mid:%u", slot.mid_audio);
     if (n < 0 || (size_t)n >= sizeof(buf) || append_line_n(out, out_cap, &off, buf, (size_t)n) != 0) {
-      return -1;
+      goto fail;
     }
     if (append_line(out, out_cap, &off, "a=rtcp-mux") != 0) {
-      return -1;
+      goto fail;
     }
     if (append_line(out, out_cap, &off, "a=rtpmap:111 opus/48000/2") != 0) {
-      return -1;
+      goto fail;
     }
     if (audio_live) {
-      if (append_remote_audio_ssrcs(out, out_cap, &off, slot->audio->ssrc, slot->audio->owner->cold->ufrag) != 0) {
-        return -1;
+      if (append_remote_audio_ssrcs(out, out_cap, &off, slot.audio_ssrc, slot.owner_ufrag) != 0) {
+        goto fail;
       }
     }
 
 
-    uint8_t remote_video_pt = (video_live && slot->video->payload_type != 0) ? slot->video->payload_type : local_video_pt;
-    uint8_t remote_rtx_pt = (video_live && slot->video->rtx_payload_type != 0) ? slot->video->rtx_payload_type : local_rtx_pt;
+    uint8_t remote_video_pt = (video_live && slot.video_pt != 0) ? slot.video_pt : local_video_pt;
+    uint8_t remote_rtx_pt = (video_live && slot.video_rtx_pt != 0) ? slot.video_rtx_pt : local_rtx_pt;
 
     if (remote_rtx_pt != 0) {
       n = snprintf(buf, sizeof(buf), "m=video %u UDP/TLS/RTP/SAVPF %u %u", port, remote_video_pt, remote_rtx_pt);
@@ -647,30 +665,35 @@ int sfu_sdp_build_offer(const sfu_peer_session_t *session, const char *host, uin
       n = snprintf(buf, sizeof(buf), "m=video %u UDP/TLS/RTP/SAVPF %u", port, remote_video_pt);
     }
     if (n < 0 || (size_t)n >= sizeof(buf) || append_line_n(out, out_cap, &off, buf, (size_t)n) != 0) {
-      return -1;
+      goto fail;
     }
     if (append_media_transport_headers(out, out_cap, &off, host, port, ufrag, pwd, fingerprint) != 0) {
-      return -1;
+      goto fail;
     }
     if (append_line(out, out_cap, &off, video_live ? "a=sendonly" : "a=inactive") != 0) {
-      return -1;
+      goto fail;
     }
-    n = snprintf(buf, sizeof(buf), "a=mid:%u", slot->mid_video);
+    n = snprintf(buf, sizeof(buf), "a=mid:%u", slot.mid_video);
     if (n < 0 || (size_t)n >= sizeof(buf) || append_line_n(out, out_cap, &off, buf, (size_t)n) != 0) {
-      return -1;
+      goto fail;
     }
     if (append_line(out, out_cap, &off, "a=rtcp-mux") != 0) {
-      return -1;
+      goto fail;
     }
     if (append_video_codec_attributes(out, out_cap, &off, remote_video_pt, remote_rtx_pt) != 0) {
-      return -1;
+      goto fail;
     }
     if (video_live) {
-      if (append_remote_video_ssrcs(out, out_cap, &off, slot->video->ssrc, slot->video->rtx_ssrc, slot->video->owner->cold->ufrag) != 0) {
-        return -1;
+      if (append_remote_video_ssrcs(out, out_cap, &off, slot.video_ssrc, slot.video_rtx_ssrc, slot.owner_ufrag) != 0) {
+        goto fail;
       }
     }
   }
 
+  sfu_receiver_snapshot_release(snap);
   return (int)off;
+
+fail:
+  sfu_receiver_snapshot_release(snap);
+  return -1;
 }

--- a/src/protocol/signaling/sdp.h
+++ b/src/protocol/signaling/sdp.h
@@ -32,6 +32,24 @@ static inline sfu_video_codec_t sfu_video_codec_from_pt(uint8_t pt) {
   }
 }
 
+/* Read-only view over one receiver-snapshot entry used by the SDP builders.
+ * Plain value type (no ownership); the SDP caller must hold the snapshot it
+ * was filled from, or be running under the room lock. */
+typedef struct sfu_sdp_receiver_view {
+  uint32_t audio_ssrc;
+  uint32_t video_ssrc;
+  uint32_t video_rtx_ssrc;
+  uint32_t mid_audio;
+  uint32_t mid_video;
+  uint8_t video_pt;
+  uint8_t video_rtx_pt;
+  bool has_audio;
+  bool has_video;
+  bool audio_active;
+  bool video_active;
+  char owner_ufrag[32];
+} sfu_sdp_receiver_view_t;
+
 int sfu_sdp_build_answer(const sfu_peer_session_t *session, const char *offer, size_t offer_len, const char *host, uint16_t port, const char *ufrag,
                          const char *pwd, const char *fingerprint, char *out, size_t out_cap);
 

--- a/src/protocol/signaling/signaling.c
+++ b/src/protocol/signaling/signaling.c
@@ -321,7 +321,7 @@ void sfu_signaling_trigger_renegotiation(sfu_room_t *room) {
   for (uint32_t i = 0; i < room->peer_count; i++) {
     sfu_peer_session_t *session = room->peers[i];
 
-    if (!session) {
+    if (!session || !sfu_session_accepts_work(session)) {
       continue;
     }
 
@@ -429,20 +429,21 @@ static int extract_header_val(const char *handshake, const char *header_name, ch
 static void on_client_close(uv_handle_t *handle) {
   sfu_client_conn_t *c = (sfu_client_conn_t *)handle->data;
 
-  SFU_LOG_INFO("signaling: on_client_close fired for fd=%d ufrag=%s session=%p", c->fd, c->client_ufrag, (void *)c->session);
-
-  sfu_peer_session_t *session = c->session;
-  if (!session && c->client_ufrag[0] != '\0') {
-    session = sfu_session_table_find_by_ufrag(c->server->sessions, c->client_ufrag);
-  }
+  SFU_LOG_INFO("signaling: on_client_close fired for fd=%d ufrag=%s", c->fd, c->client_ufrag);
 
   sfu_routing_table_unregister_fd(c->server->routing_table, c->fd);
 
+  /* Fresh acquired ufrag lookup (c->session is never a valid reference; the
+   * borrowed pointer was removed in Phase 3). The pin keeps the session alive
+   * across begin_close, which is idempotent and detaches the room itself. */
+  sfu_peer_session_t *session = NULL;
+  if (c->client_ufrag[0] != '\0') {
+    session = sfu_session_table_find_by_ufrag(c->server->sessions, c->client_ufrag);
+  }
+
   if (session) {
-    if (session->room) {
-      room_remove_peer(session->room, session);
-    }
-    sfu_session_table_remove(c->server->sessions, session);
+    (void)sfu_session_begin_close(c->server->sessions, session);
+    sfu_session_release(session);
   }
 
   close(c->fd);
@@ -567,12 +568,14 @@ static void on_client_readable(uv_poll_t *handle, int status, int events) {
                 } else {
                   c->client_ufrag[0] = '\0';
                 }
+                /* Acquired pin, used and released within this callback; the
+                 * borrowed c->session pointer was removed in Phase 3. */
                 sfu_peer_session_t *session = sfu_session_table_find_by_ufrag(s->sessions, c->client_ufrag);
                 if (session) {
-                  c->session = session;
-                  c->session->user_id = c->user_id;
-                  c->session->peer_id = generate_unique_id();
+                  session->user_id = c->user_id;
+                  session->peer_id = generate_unique_id();
                   handle_answer(session, sdp, sdp_len);
+                  sfu_session_release(session);
                 } else {
                   uint32_t audio_ssrc = 0, video_ssrc = 0, rtx_ssrc = 0;
                   uint8_t video_pt = 0, rtx_pt = 0;

--- a/src/protocol/signaling/signaling.h
+++ b/src/protocol/signaling/signaling.h
@@ -28,7 +28,9 @@ typedef struct sfu_client_conn {
   uv_poll_t poll_handle;
   uv_timer_t answer_retry_timer;
   sfu_signaling_server_t *server;
-  sfu_peer_session_t *session;
+  /* NOTE: no cached session pointer. The borrowed c->session was removed in
+   * Phase 3 (F-01): sessions are refcounted and every use goes through a
+   * fresh acquired lookup (find_by_ufrag) plus sfu_session_release. */
   sfu_room_t *joined_room;
   uint64_t joined_room_id;
   int64_t user_id;

--- a/src/room/room_media_graph.c
+++ b/src/room/room_media_graph.c
@@ -1,55 +1,142 @@
 #include "room/room_media_graph.h"
+#include <inttypes.h>
 #include <pthread.h>
+#include <string.h>
+#include "peer/session.h"
 #include "util/alloc.h"
 #include "util/log.h"
 
-static sfu_receiver_slot_t *alloc_receiver_slot(sfu_peer_session_t *peer, sfu_scheduler_t *scheduler) {
-  for (uint32_t i = 0; i < peer->receiver_capacity; i++) {
-    sfu_receiver_slot_t *slot = peer->receivers[i];
-    if (slot && slot->audio == NULL && slot->video == NULL) {
-      return slot;
+/* ---------------------------------------------------------------------------
+ * Copy-on-write receiver snapshots (F-03/F-04)
+ *
+ * room_add_peer / room_remove_peer never mutate a receiver slot in place.
+ * For every affected peer they build a fully-populated replacement snapshot
+ * (retaining a reference on each destination session) and release-store it;
+ * the superseded snapshot keeps serving in-flight readers until they release
+ * it. An allocation failure leaves the peer's current snapshot untouched and
+ * is reported via the return value of the builder.
+ * ------------------------------------------------------------------------- */
+
+/* Copies immutable routing metadata for destination `dst` into `e` and takes
+ * a reference on `dst`. Call with the room lock held. */
+static void snapshot_fill_entry(sfu_receiver_entry_t *e, sfu_peer_session_t *dst) {
+  atomic_fetch_add_explicit(&dst->refcount, 1, memory_order_relaxed);
+
+  e->subscriber = dst;
+  if (dst->cold) {
+    snprintf(e->subscriber_ufrag, sizeof(e->subscriber_ufrag), "%s", dst->cold->ufrag);
+  } else {
+    e->subscriber_ufrag[0] = '\0';
+  }
+
+  e->audio_ssrc = dst->uplink_audio.ssrc;
+  e->video_ssrc = dst->uplink_video.ssrc;
+  e->video_rtx_ssrc = dst->uplink_video.rtx_ssrc;
+  e->video_pt = dst->uplink_video.payload_type;
+  e->video_rtx_pt = dst->uplink_video.rtx_payload_type;
+  e->audio_active = dst->uplink_audio.active;
+  e->video_active = dst->uplink_video.active;
+}
+
+/* Finds the slot position of destination `dst` in `old`, or UINT32_MAX. */
+static uint32_t snapshot_find(const sfu_receiver_snapshot_t *old, const sfu_peer_session_t *dst) {
+  if (!old) {
+    return UINT32_MAX;
+  }
+  for (uint32_t i = 0; i < old->count; i++) {
+    if (old->entries[i].subscriber == dst) {
+      return i;
     }
   }
+  return UINT32_MAX;
+}
 
-  uint32_t new_capacity = peer->receiver_capacity == 0 ? 4 : peer->receiver_capacity * 2;
-  sfu_receiver_slot_t **new_array = SFU_CALLOC(new_capacity, sizeof(*new_array));
-  if (!new_array) {
+static sfu_receiver_snapshot_t *snapshot_alloc(uint32_t capacity) {
+  sfu_receiver_snapshot_t *snap = SFU_CALLOC(1, sizeof(*snap) + (size_t)capacity * sizeof(snap->entries[0]));
+  if (!snap) {
     return NULL;
   }
-  for (uint32_t i = 0; i < peer->receiver_capacity; i++) {
-    new_array[i] = peer->receivers[i];
+  atomic_store_explicit(&snap->refcount, 1, memory_order_relaxed);
+  snap->capacity = capacity;
+  return snap;
+}
+
+/* Builds "old snapshot + dst appended". MID numbers are preserved across
+ * replacements for SDP stability; a brand-new destination consumes fresh MIDs
+ * from the owner's counter. Returns NULL on allocation failure, leaving the
+ * peer's published snapshot unchanged. Call with the room lock held. */
+static sfu_receiver_snapshot_t *snapshot_build_with(sfu_peer_session_t *owner, sfu_peer_session_t *dst) {
+  sfu_receiver_snapshot_t *old = atomic_load_explicit(&owner->receivers, memory_order_acquire);
+  if (snapshot_find(old, dst) != UINT32_MAX) {
+    return NULL; /* already routed */
   }
 
-  sfu_receiver_slot_t *slot = SFU_CALLOC(1, sizeof(*slot));
-  if (!slot) {
-    SFU_FREE(new_array);
+  uint32_t old_count = old ? old->count : 0;
+  sfu_receiver_snapshot_t *snap = snapshot_alloc(old_count + 1);
+  if (!snap) {
     return NULL;
   }
+  snap->generation = (old ? old->generation : 0) + 1;
 
-  slot->mid_audio = peer->next_remote_mid++;
-  slot->mid_video = peer->next_remote_mid++;
+  for (uint32_t i = 0; i < old_count; i++) {
+    snap->entries[i] = old->entries[i]; /* value copy; ref re-taken below */
+    atomic_fetch_add_explicit(&old->entries[i].subscriber->refcount, 1, memory_order_relaxed);
+  }
 
-  new_array[peer->receiver_capacity] = slot;
+  sfu_receiver_entry_t *e = &snap->entries[old_count];
+  memset(e, 0, sizeof(*e));
+  /* snapshot_find returned UINT32_MAX above, so dst is a new destination and
+   * consumes fresh MIDs from the owner's monotonic counter. */
+  e->mid_audio = owner->next_remote_mid++;
+  e->mid_video = owner->next_remote_mid++;
+  snapshot_fill_entry(e, dst);
+  e->has_audio = true;
+  e->has_video = true;
 
-  sfu_receiver_slot_t **old_array = peer->receivers;
+  snap->count = old_count + 1;
+  return snap;
+}
 
-  __atomic_store_n(&peer->receiver_capacity, new_capacity, __ATOMIC_RELEASE);
-  __atomic_store_n(&peer->receivers, new_array, __ATOMIC_RELEASE);
+/* Builds "old snapshot minus dst". Slot positions and MID numbers of all
+ * remaining destinations are preserved. Returns NULL on allocation failure,
+ * leaving the peer's published snapshot unchanged. Call with room lock held. */
+static sfu_receiver_snapshot_t *snapshot_build_without(sfu_peer_session_t *owner, const sfu_peer_session_t *dst) {
+  sfu_receiver_snapshot_t *old = atomic_load_explicit(&owner->receivers, memory_order_acquire);
+  uint32_t pos = snapshot_find(old, dst);
+  if (pos == UINT32_MAX) {
+    return NULL; /* dst not routed to owner */
+  }
 
-  if (old_array) {
-    if (scheduler) {
-      if (!sfu_scheduler_retire_ptr(scheduler, old_array)) {
-        SFU_LOG_ERROR("alloc_receiver_slot: retirement failed for old_array=%p; leaking safely", (void *)old_array);
-      }
-    } else {
-      SFU_LOG_ERROR("alloc_receiver_slot: no scheduler to retire old_array=%p, leaking", (void *)old_array);
+  uint32_t old_count = old->count;
+  sfu_receiver_snapshot_t *snap = snapshot_alloc(old_count - 1);
+  if (!snap) {
+    return NULL;
+  }
+  snap->generation = old->generation + 1;
+
+  uint32_t out = 0;
+  for (uint32_t i = 0; i < old_count; i++) {
+    if (i == pos) {
+      continue;
     }
+    snap->entries[out] = old->entries[i]; /* value copy; ref re-taken below */
+    atomic_fetch_add_explicit(&old->entries[i].subscriber->refcount, 1, memory_order_relaxed);
+    out++;
   }
+  snap->count = out;
+  return snap;
+}
 
-  return slot;
+/* Replaces `owner`'s published snapshot with `new_snap` (taking ownership of
+ * it) and marks the owner for renegotiation. Call with the room lock held. */
+static void snapshot_replace(sfu_peer_session_t *owner, sfu_receiver_snapshot_t *new_snap) {
+  sfu_session_publish_receivers(owner, new_snap);
+  owner->negotiation_needed = true;
 }
 
 void room_add_peer(sfu_room_t *room, sfu_peer_session_t *peer, sfu_scheduler_t *scheduler) {
+  (void)scheduler; /* snapshots are self-refcounted; no epoch retirement */
+
   pthread_mutex_lock(&room->lock);
 
   if (peer->room == room) {
@@ -71,24 +158,29 @@ void room_add_peer(sfu_room_t *room, sfu_peer_session_t *peer, sfu_scheduler_t *
       continue;
     }
 
-    sfu_receiver_slot_t *slot = alloc_receiver_slot(other, scheduler);
-    if (slot) {
-      slot->audio = &peer->uplink_audio;
-      slot->video = &peer->uplink_video;
-    } else {
-      SFU_LOG_WARN("room %" PRIu64 ": failed to allocate receiver slot for peer subscribing to %s", room->room_id, peer->cold->ufrag);
+    /* Routing is only wired between peers that both still accept work; a
+     * closing peer is never added as a destination nor given new routes. */
+    if (!sfu_session_accepts_work(other) || !sfu_session_accepts_work(peer)) {
+      continue;
     }
 
-    slot = alloc_receiver_slot(peer, scheduler);
-    if (slot) {
-      slot->audio = &other->uplink_audio;
-      slot->video = &other->uplink_video;
+    /* other subscribes to the new peer's uplink */
+    sfu_receiver_snapshot_t *snap = snapshot_build_with(other, peer);
+    if (snap) {
+      snapshot_replace(other, snap);
     } else {
-      SFU_LOG_WARN("room %" PRIu64 ": failed to allocate receiver slot for %s subscribing to peer", room->room_id, peer->cold->ufrag);
+      SFU_LOG_WARN("room %" PRIu64 ": failed to build receiver snapshot for peer subscribing to %s", room->room_id,
+                   peer->cold ? peer->cold->ufrag : "?");
     }
 
-    other->negotiation_needed = true;
-    peer->negotiation_needed = true;
+    /* the new peer subscribes to other's uplink */
+    snap = snapshot_build_with(peer, other);
+    if (snap) {
+      snapshot_replace(peer, snap);
+    } else {
+      SFU_LOG_WARN("room %" PRIu64 ": failed to build receiver snapshot for %s subscribing to peer", room->room_id,
+                   peer->cold ? peer->cold->ufrag : "?");
+    }
   }
 
   pthread_mutex_unlock(&room->lock);
@@ -97,6 +189,13 @@ void room_add_peer(sfu_room_t *room, sfu_peer_session_t *peer, sfu_scheduler_t *
 void room_remove_peer(sfu_room_t *room, sfu_peer_session_t *peer) {
   pthread_mutex_lock(&room->lock);
 
+  if (peer->room != room) {
+    /* Already detached (or never a member): idempotent no-op. peer->room is
+     * only ever written under the room lock, so this check is race-free. */
+    pthread_mutex_unlock(&room->lock);
+    return;
+  }
+
   uint32_t idx = UINT32_MAX;
   for (uint32_t i = 0; i < room->peer_count; i++) {
     if (room->peers[i] == peer) {
@@ -104,42 +203,38 @@ void room_remove_peer(sfu_room_t *room, sfu_peer_session_t *peer) {
       break;
     }
   }
-  if (idx != UINT32_MAX) {
-    room->peers[idx] = room->peers[room->peer_count - 1];
-    room->peers[room->peer_count - 1] = NULL;
-    room->peer_count--;
+
+  if (idx == UINT32_MAX) {
+    /* Defensive: back-pointer says member but the array disagrees. */
+    peer->room = NULL;
+    pthread_mutex_unlock(&room->lock);
+    return;
   }
 
+  room->peers[idx] = room->peers[room->peer_count - 1];
+  room->peers[room->peer_count - 1] = NULL;
+  room->peer_count--;
+
+  /* Rebuild every remaining peer's snapshot without the departing peer. */
   for (uint32_t i = 0; i < room->peer_count; i++) {
     sfu_peer_session_t *other = room->peers[i];
-    if (!other || !other->receivers) {
+    if (!other) {
       continue;
     }
-
-    bool touched = false;
-    for (uint32_t s = 0; s < other->receiver_capacity; s++) {
-      sfu_receiver_slot_t *slot = other->receivers[s];
-      if (!slot) {
-        continue;
-      }
-      if ((slot->audio && slot->audio->owner == peer) || (slot->video && slot->video->owner == peer)) {
-        slot->audio = NULL;
-        slot->video = NULL;
-        touched = true;
-      }
-    }
-    if (touched) {
-      other->negotiation_needed = true;
+    sfu_receiver_snapshot_t *snap = snapshot_build_without(other, peer);
+    if (snap) {
+      snapshot_replace(other, snap);
     }
   }
 
-  if (peer->receivers) {
-    for (uint32_t i = 0; i < peer->receiver_capacity; i++) {
-      if (peer->receivers[i]) {
-        peer->receivers[i]->audio = NULL;
-        peer->receivers[i]->video = NULL;
-      }
-    }
+  /* The departing peer's own snapshot is dropped entirely. */
+  sfu_receiver_snapshot_t *empty = snapshot_alloc(0);
+  if (empty) {
+    empty->generation = 0;
+    sfu_session_publish_receivers(peer, empty);
+  } else {
+    SFU_LOG_ERROR("room %" PRIu64 ": failed to allocate empty snapshot; clearing receivers in place", room->room_id);
+    sfu_session_publish_receivers(peer, NULL);
   }
 
   peer->room = NULL;

--- a/src/room/room_media_graph.h
+++ b/src/room/room_media_graph.h
@@ -4,6 +4,13 @@
 #include "runtime/scheduler.h"
 #include "sfu/datadef.h"
 
+/* Room membership drives copy-on-write replacement of every affected peer's
+ * immutable receiver snapshot (F-03/F-04). Both functions are no-ops for
+ * sessions that no longer accept work (closing/closed), so a close racing
+ * membership changes never resurrects routing state.
+ *
+ * `scheduler` is accepted for API compatibility; retirement no longer needs
+ * the epoch reclaimer because snapshots are self-refcounted. */
 void room_add_peer(sfu_room_t *room, sfu_peer_session_t *peer, sfu_scheduler_t *scheduler);
 void room_remove_peer(sfu_room_t *room, sfu_peer_session_t *peer);
 

--- a/src/runtime/worker.c
+++ b/src/runtime/worker.c
@@ -301,6 +301,9 @@ static void sfu_worker_handle_rtcp(sfu_worker_t *w, sfu_peer_session_t *sender_s
 }
 
 void sfu_room_forward_packet(sfu_worker_t *w, sfu_packet_t *pkt) {
+  /* Sender pin (F-01): the acquired reference covers the entire packet path,
+   * so the session (and its SRTP/RTX state) stays valid even if the session
+   * is concurrently closed elsewhere. */
   sfu_peer_session_t *sender_session = sfu_session_table_find(w->sessions, &pkt->peer_addr, pkt->peer_addr_len);
 
   if (!sender_session) {
@@ -311,6 +314,7 @@ void sfu_room_forward_packet(sfu_worker_t *w, sfu_packet_t *pkt) {
   if (sender_session->state != SFU_SESSION_ESTABLISHED) {
     SFU_LOG_WARN("worker %u: [INGRESS DROP] RTP from unestablished session (state=%d)! pkt_len=%u", w->worker_index, sender_session->state, pkt->len);
     sfu_worker_release_packet(w->pp, &w->release_to_dispatcher, pkt);
+    sfu_session_release(sender_session);
     return;
   }
 
@@ -322,12 +326,14 @@ void sfu_room_forward_packet(sfu_worker_t *w, sfu_packet_t *pkt) {
   if (!unprotected) {
     SFU_LOG_WARN("worker %u: [INGRESS DROP] SRTP unprotect FAILED (is_rtcp=%d, len=%u). Key mismatch or corrupted packet!", w->worker_index, is_rtcp, pkt->len);
     sfu_worker_release_packet(w->pp, &w->release_to_dispatcher, pkt);
+    sfu_session_release(sender_session);
     return;
   }
   pkt->len = (uint32_t)plain_len;
 
   if (is_rtcp) {
-    sfu_worker_handle_rtcp(w, sender_session, pkt);
+    sfu_worker_handle_rtcp(w, sender_session, pkt); /* consumes pkt */
+    sfu_session_release(sender_session);
     return;
   }
 
@@ -353,17 +359,17 @@ void sfu_room_forward_packet(sfu_worker_t *w, sfu_packet_t *pkt) {
     }
   }
 
-  sfu_receiver_slot_t **receivers = __atomic_load_n(&sender_session->receivers, __ATOMIC_ACQUIRE);
-  uint32_t receiver_capacity = __atomic_load_n(&sender_session->receiver_capacity, __ATOMIC_ACQUIRE);
+  /* Immutable receiver snapshot (F-03/F-04): one coherent view of the
+   * subscriber set for the whole packet. Every entry's subscriber session is
+   * retained by the snapshot, so it is safe to use for the full forwarding
+   * path without any additional pinning (F-01). */
+  sfu_receiver_snapshot_t *snap = sfu_session_receivers_acquire(sender_session);
+  uint32_t receiver_count = snap ? snap->count : 0;
 
-  for (uint32_t i = 0; i < receiver_capacity; i++) {
-    sfu_receiver_slot_t *slot = receivers[i];
+  for (uint32_t i = 0; i < receiver_count; i++) {
+    const sfu_receiver_entry_t *slot = &snap->entries[i];
 
-    if (!slot || (!slot->video && !slot->audio)) {
-      continue;
-    }
-
-    sfu_peer_session_t *sub_session = slot->video ? slot->video->owner : slot->audio->owner;
+    sfu_peer_session_t *sub_session = slot->subscriber;
     if (!sub_session || sub_session->state != SFU_SESSION_ESTABLISHED) {
       continue;
     }
@@ -376,7 +382,7 @@ void sfu_room_forward_packet(sfu_worker_t *w, sfu_packet_t *pkt) {
       continue;
     }
 
-    if (is_vp9 && slot->video) {
+    if (is_vp9 && slot->has_video) {
       bool should_forward = sfu_scheduler_evaluate_frame(sub_session->scheduler, &vp9_desc, is_keyframe);
       if (!should_forward) {
         continue;
@@ -405,8 +411,8 @@ void sfu_room_forward_packet(sfu_worker_t *w, sfu_packet_t *pkt) {
       }
 
       uint16_t subscriber_seq = sfu_read_be16(enc->data + 2);
-      if (slot->video && incoming_pt == slot->video->payload_type) {
-        sfu_rtx_cache_put(sub_session->rtx_cache, subscriber_seq, enc->data, enc_len, slot->video->rtx_ssrc, slot->video->rtx_payload_type);
+      if (slot->has_video && incoming_pt == slot->video_pt) {
+        sfu_rtx_cache_put(sub_session->rtx_cache, subscriber_seq, enc->data, enc_len, slot->video_rtx_ssrc, slot->video_rtx_pt);
       }
 
       uint16_t twcc_seq = __atomic_fetch_add(&sub_session->next_twcc_seq, 1, __ATOMIC_RELAXED);
@@ -439,6 +445,8 @@ void sfu_room_forward_packet(sfu_worker_t *w, sfu_packet_t *pkt) {
     }
   }
 
+  sfu_receiver_snapshot_release(snap);
+  sfu_session_release(sender_session);
   sfu_worker_release_packet(w->pp, &w->release_to_dispatcher, pkt);
 }
 

--- a/tests/test_room.c
+++ b/tests/test_room.c
@@ -1,100 +1,252 @@
 #include <assert.h>
+#include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "peer/session.h"
 #include "room/room.h"
 #include "room/room_media_graph.h"
 #include "runtime/scheduler.h"
+#include "util/alloc.h"
+
+/* Heap-allocated refcounted mock session (no DTLS/RTX; construction bypasses
+ * the session table because these tests exercise the room graph, not DTLS). */
+static sfu_peer_session_t *mock_session(const char *ufrag) {
+  sfu_peer_session_t *s = SFU_CALLOC(1, sizeof(*s));
+  assert(s != NULL);
+  s->cold = SFU_CALLOC(1, sizeof(*s->cold));
+  assert(s->cold != NULL);
+  snprintf(s->cold->ufrag, sizeof(s->cold->ufrag), "%s", ufrag);
+  s->active = true;
+  atomic_store(&s->refcount, 1);
+  atomic_store(&s->lifecycle, SFU_SESSION_LIFECYCLE_OPEN);
+  atomic_store(&s->accepts_work, true);
+  s->uplink_audio.owner = s;
+  s->uplink_video.owner = s;
+  s->uplink_audio.active = true;
+  s->uplink_video.active = true;
+  s->next_remote_mid = 2;
+  return s;
+}
 
 static uint32_t receiver_count(sfu_peer_session_t *peer) {
-  uint32_t n = 0;
-
-  for (uint32_t i = 0; i < peer->receiver_capacity; i++) {
-    if (peer->receivers && peer->receivers[i] && (peer->receivers[i]->audio || peer->receivers[i]->video)) {
-      n++;
-    }
-  }
-
+  sfu_receiver_snapshot_t *snap = sfu_session_receivers_acquire(peer);
+  uint32_t n = snap ? snap->count : 0;
+  sfu_receiver_snapshot_release(snap);
   return n;
 }
 
-int main(void) {
+static bool subscribes_to(sfu_peer_session_t *peer, sfu_peer_session_t *dest) {
+  sfu_receiver_snapshot_t *snap = sfu_session_receivers_acquire(peer);
+  bool found = false;
+  if (snap) {
+    for (uint32_t i = 0; i < snap->count; i++) {
+      if (snap->entries[i].subscriber == dest) {
+        found = true;
+        break;
+      }
+    }
+  }
+  sfu_receiver_snapshot_release(snap);
+  return found;
+}
+
+static void test_add_remove(void) {
   sfu_room_t room;
   sfu_scheduler_t scheduler = {0};
 
   assert(sfu_room_init(&room, 1) == 0);
 
-  sfu_peer_session_t a = {0};
-  sfu_peer_session_t b = {0};
-  sfu_peer_session_t c = {0};
+  sfu_peer_session_t *a = mock_session("a");
+  sfu_peer_session_t *b = mock_session("b");
+  sfu_peer_session_t *c = mock_session("c");
 
-  a.active = true;
-  b.active = true;
-  c.active = true;
+  room_add_peer(&room, a, &scheduler);
+  assert(receiver_count(a) == 0);
 
-  /* Allocate cold pointers for stack-allocated sessions */
-  a.cold = calloc(1, sizeof(sfu_peer_session_cold_t));
-  b.cold = calloc(1, sizeof(sfu_peer_session_cold_t));
-  c.cold = calloc(1, sizeof(sfu_peer_session_cold_t));
-  assert(a.cold && b.cold && c.cold);
+  room_add_peer(&room, b, &scheduler);
+  assert(receiver_count(a) == 1);
+  assert(receiver_count(b) == 1);
+  assert(subscribes_to(a, b));
+  assert(subscribes_to(b, a));
 
-  strcpy(a.cold->ufrag, "a");
-  strcpy(b.cold->ufrag, "b");
-  strcpy(c.cold->ufrag, "c");
+  room_add_peer(&room, c, &scheduler);
+  assert(receiver_count(a) == 2);
+  assert(receiver_count(b) == 2);
+  assert(receiver_count(c) == 2);
+  assert(subscribes_to(a, b));
+  assert(subscribes_to(a, c));
 
-  a.uplink_audio.active = true;
-  a.uplink_video.active = true;
-
-  b.uplink_audio.active = true;
-  b.uplink_video.active = true;
-
-  c.uplink_audio.active = true;
-  c.uplink_video.active = true;
-
-  room_add_peer(&room, &a, &scheduler);
-
-  assert(receiver_count(&a) == 0);
-
-  room_add_peer(&room, &b, &scheduler);
-
-  assert(receiver_count(&a) == 1);
-  assert(receiver_count(&b) == 1);
-
-  room_add_peer(&room, &c, &scheduler);
-
-  assert(receiver_count(&a) == 2);
-  assert(receiver_count(&b) == 2);
-  assert(receiver_count(&c) == 2);
-
-  /* Verify A subscribes to B and C */
-  bool saw_b = false;
-  bool saw_c = false;
-
-  for (uint32_t i = 0; i < a.receiver_capacity; i++) {
-    sfu_receiver_slot_t *slot = a.receivers[i];
-
-    if (!slot || !slot->video) {
-      continue;
+  /* MID numbers are stable for surviving entries across a removal. */
+  uint32_t a_mid_for_c_audio = 0, a_mid_for_c_video = 0;
+  {
+    sfu_receiver_snapshot_t *snap = sfu_session_receivers_acquire(a);
+    assert(snap != NULL);
+    for (uint32_t i = 0; i < snap->count; i++) {
+      if (snap->entries[i].subscriber == c) {
+        a_mid_for_c_audio = snap->entries[i].mid_audio;
+        a_mid_for_c_video = snap->entries[i].mid_video;
+      }
     }
+    sfu_receiver_snapshot_release(snap);
+  }
+  assert(a_mid_for_c_audio != 0 || a_mid_for_c_video != 0);
 
-    if (slot->video == &b.uplink_video) {
-      saw_b = true;
-    }
+  room_remove_peer(&room, b);
+  assert(receiver_count(a) == 1);
+  assert(receiver_count(c) == 1);
+  assert(!subscribes_to(a, b));
+  assert(subscribes_to(a, c));
+  assert(b->room == NULL);
+  assert(receiver_count(b) == 0);
 
-    if (slot->video == &c.uplink_video) {
-      saw_c = true;
-    }
+  /* c's MIDs inside a's snapshot survived the rebuild. */
+  {
+    sfu_receiver_snapshot_t *snap = sfu_session_receivers_acquire(a);
+    assert(snap != NULL && snap->count == 1);
+    assert(snap->entries[0].subscriber == c);
+    assert(snap->entries[0].mid_audio == a_mid_for_c_audio);
+    assert(snap->entries[0].mid_video == a_mid_for_c_video);
+    sfu_receiver_snapshot_release(snap);
   }
 
-  assert(saw_b);
-  assert(saw_c);
+  /* Removing a non-member is a safe no-op. */
+  room_remove_peer(&room, b);
+  assert(receiver_count(a) == 1);
 
-  /* Clean up cold pointers */
-  free(a.cold);
-  free(b.cold);
-  free(c.cold);
+  /* Closing peer c (accepts_work=false) keeps it out of future snapshots. */
+  atomic_store(&c->accepts_work, false);
+  room_add_peer(&room, b, &scheduler);
+  /* re-add is a no-op: b is still a member from the rejoin above */
+  assert(receiver_count(b) == 1); /* b sees a only */
+  assert(!subscribes_to(b, c));
+  assert(subscribes_to(a, b)); /* a still accepts work, so it routes to b */
+  assert(receiver_count(a) == 2);
+
+  sfu_session_release(a);
+  sfu_session_release(b);
+  sfu_session_release(c);
 
   sfu_room_destroy(&room);
+}
+
+/* Old snapshot stays valid for a holder across a concurrent replacement. */
+static void test_snapshot_hold_across_replace(void) {
+  sfu_room_t room;
+  sfu_scheduler_t scheduler = {0};
+  assert(sfu_room_init(&room, 2) == 0);
+
+  sfu_peer_session_t *a = mock_session("a");
+  sfu_peer_session_t *b = mock_session("b");
+  sfu_peer_session_t *c = mock_session("c");
+
+  room_add_peer(&room, a, &scheduler);
+  room_add_peer(&room, b, &scheduler);
+
+  /* Hold the current snapshot of a. */
+  sfu_receiver_snapshot_t *held = sfu_session_receivers_acquire(a);
+  assert(held != NULL && held->count == 1);
+  assert(held->entries[0].subscriber == b);
+
+  /* Writer publishes a replacement while we hold the old one. */
+  room_add_peer(&room, c, &scheduler);
+
+  /* The held (old) snapshot is unchanged and its entries are still valid. */
+  assert(held->count == 1);
+  assert(held->entries[0].subscriber == b);
+  assert(held->entries[0].subscriber->cold != NULL);
+
+  /* New acquisitions see the replacement. */
+  sfu_receiver_snapshot_t *fresh = sfu_session_receivers_acquire(a);
+  assert(fresh != NULL && fresh->count == 2);
+  assert(fresh != held);
+  assert(fresh->generation == held->generation + 1);
+  sfu_receiver_snapshot_release(fresh);
+
+  /* Releasing the held snapshot must not free b (still referenced by the new
+   * snapshot and by our own pin). */
+  sfu_receiver_snapshot_release(held);
+  assert(b->cold != NULL);
+  assert(subscribes_to(a, b));
+
+  sfu_session_release(a);
+  sfu_session_release(b);
+  sfu_session_release(c);
+  sfu_room_destroy(&room);
+}
+
+typedef struct {
+  sfu_room_t *room;
+  sfu_peer_session_t **peers;
+  uint32_t peer_count;
+  pthread_barrier_t barrier;
+} snap_race_ctx_t;
+
+static void *snap_reader(void *arg) {
+  snap_race_ctx_t *ctx = arg;
+  pthread_barrier_wait(&ctx->barrier);
+  for (int i = 0; i < 500; i++) {
+    sfu_receiver_snapshot_t *snap = sfu_session_receivers_acquire(ctx->peers[0]);
+    if (snap) {
+      for (uint32_t e = 0; e < snap->count; e++) {
+        /* Entries must be coherent: retained subscriber with valid cold. */
+        assert(snap->entries[e].subscriber != NULL);
+        assert(snap->entries[e].subscriber->cold != NULL);
+      }
+      sfu_receiver_snapshot_release(snap);
+    }
+  }
+  return NULL;
+}
+
+static void *snap_writer(void *arg) {
+  snap_race_ctx_t *ctx = arg;
+  sfu_scheduler_t scheduler = {0};
+  pthread_barrier_wait(&ctx->barrier);
+  for (int i = 0; i < 50; i++) {
+    room_add_peer(ctx->room, ctx->peers[1], &scheduler);
+    room_remove_peer(ctx->room, ctx->peers[1]);
+  }
+  return NULL;
+}
+
+/* Concurrent snapshot reads vs copy-on-write replacement (TSan target). */
+static void test_concurrent_snapshot_read_write(void) {
+  sfu_room_t room;
+  assert(sfu_room_init(&room, 3) == 0);
+
+  sfu_peer_session_t *peers[2];
+  peers[0] = mock_session("reader-owner");
+  peers[1] = mock_session("flapper");
+
+  snap_race_ctx_t ctx = {
+      .room = &room, .peers = peers, .peer_count = 2,
+  };
+  pthread_barrier_init(&ctx.barrier, NULL, 2);
+
+  sfu_scheduler_t scheduler = {0};
+  room_add_peer(&room, peers[0], &scheduler);
+
+  pthread_t reader, writer;
+  assert(pthread_create(&reader, NULL, snap_reader, &ctx) == 0);
+  assert(pthread_create(&writer, NULL, snap_writer, &ctx) == 0);
+  pthread_join(reader, NULL);
+  pthread_join(writer, NULL);
+
+  pthread_barrier_destroy(&ctx.barrier);
+
+  /* Final state: flapper removed, owner has empty snapshot. */
+  assert(receiver_count(peers[0]) == 0);
+
+  sfu_session_release(peers[0]);
+  sfu_session_release(peers[1]);
+  sfu_room_destroy(&room);
+}
+
+int main(void) {
+  test_add_remove();
+  test_snapshot_hold_across_replace();
+  test_concurrent_snapshot_read_write();
 
   printf("test_room: OK\n");
   return 0;

--- a/tests/test_sdp.c
+++ b/tests/test_sdp.c
@@ -1,4 +1,5 @@
 #include "protocol/signaling/sdp.h"
+#include "peer/session.h"
 
 #include <assert.h>
 #include <stdio.h>
@@ -80,37 +81,76 @@ static int count_occurrences(const char *haystack, const char *needle) {
   return n;
 }
 
-static sfu_receiver_slot_t mock_slots[SFU_MAX_REMOTE_SLOTS];
-static sfu_receiver_slot_t *mock_slot_ptrs[SFU_MAX_REMOTE_SLOTS];
-
+/* Builds a mock session whose receiver snapshot mirrors what room_add_peer
+ * would produce for `SFU_MAX_REMOTE_SLOTS` remote publishers. The remotes are
+ * stack-allocated with refcount=1 (owned by this test) plus one ref per
+ * snapshot entry, released via the session's snapshot on cleanup. */
 static void setup_mock_session(sfu_peer_session_t *session, sfu_transceiver_t *audio, sfu_transceiver_t *video, sfu_peer_session_t *remotes) {
   memset(session, 0, sizeof(*session));
   memset(audio, 0, sizeof(*audio) * SFU_MAX_REMOTE_SLOTS);
   memset(video, 0, sizeof(*video) * SFU_MAX_REMOTE_SLOTS);
   memset(remotes, 0, sizeof(*remotes) * SFU_MAX_REMOTE_SLOTS);
-  memset(mock_slots, 0, sizeof(mock_slots));
 
   /* Allocate cold pointer for session */
   session->cold = calloc(1, sizeof(sfu_peer_session_cold_t));
   assert(session->cold != NULL);
 
-  session->receiver_capacity = SFU_MAX_REMOTE_SLOTS;
-  session->receivers = mock_slot_ptrs;
+  sfu_receiver_snapshot_t *snap = calloc(1, sizeof(*snap) + SFU_MAX_REMOTE_SLOTS * sizeof(snap->entries[0]));
+  assert(snap != NULL);
+  atomic_store(&snap->refcount, 1);
+  snap->count = SFU_MAX_REMOTE_SLOTS;
+  snap->capacity = SFU_MAX_REMOTE_SLOTS;
 
   for (uint32_t i = 0; i < SFU_MAX_REMOTE_SLOTS; i++) {
-    mock_slot_ptrs[i] = &mock_slots[i];
-    mock_slots[i].audio = &audio[i];
-    mock_slots[i].video = &video[i];
     audio[i].owner = &remotes[i];
     video[i].owner = &remotes[i];
 
     /* Allocate cold pointer for each remote peer */
     remotes[i].cold = calloc(1, sizeof(sfu_peer_session_cold_t));
     assert(remotes[i].cold != NULL);
+    atomic_store(&remotes[i].refcount, 2); /* test pin + snapshot pin */
+    atomic_store(&remotes[i].lifecycle, SFU_SESSION_LIFECYCLE_OPEN);
+    atomic_store(&remotes[i].accepts_work, true);
+
+    sfu_receiver_entry_t *e = &snap->entries[i];
+    e->subscriber = &remotes[i];
+    e->has_audio = true;
+    e->has_video = true;
+    e->mid_audio = 2 + i * 2;
+    e->mid_video = 3 + i * 2;
+  }
+
+  atomic_store(&session->receivers, snap);
+}
+
+/* Publishes the mock audio/video transceiver state into the snapshot entries
+ * (mirrors the room-media-graph copy step). Call after mutating the mock
+ * transceivers. */
+static void sync_mock_snapshot(sfu_peer_session_t *session, sfu_transceiver_t *audio, sfu_transceiver_t *video) {
+  sfu_receiver_snapshot_t *snap = atomic_load(&session->receivers);
+  assert(snap != NULL);
+  for (uint32_t i = 0; i < snap->count; i++) {
+    sfu_receiver_entry_t *e = &snap->entries[i];
+    e->audio_ssrc = audio[i].ssrc;
+    e->video_ssrc = video[i].ssrc;
+    e->video_rtx_ssrc = video[i].rtx_ssrc;
+    e->video_pt = video[i].payload_type;
+    e->video_rtx_pt = video[i].rtx_payload_type;
+    e->audio_active = audio[i].active;
+    e->video_active = video[i].active;
+    snprintf(e->subscriber_ufrag, sizeof(e->subscriber_ufrag), "%s", audio[i].owner->cold->ufrag);
   }
 }
 
 static void cleanup_mock_session(sfu_peer_session_t *session, sfu_peer_session_t *remotes) {
+  sfu_receiver_snapshot_t *snap = atomic_load(&session->receivers);
+  if (snap) {
+    atomic_store(&session->receivers, NULL);
+    /* Free the snapshot directly: the mock remotes are stack-allocated, so
+     * sfu_receiver_snapshot_release (which would sfu_session_release and
+     * ultimately free them) cannot be used here. */
+    free(snap);
+  }
   free(session->cold);
   for (uint32_t i = 0; i < SFU_MAX_REMOTE_SLOTS; i++) {
     free(remotes[i].cold);
@@ -176,7 +216,13 @@ int main(void) {
   session2.uplink_video.rtx_payload_type = 121;
   v2[0].ssrc = 987654321;
   v2[0].rtx_ssrc = 987654322;
+  v2[0].active = true;
+  /* Remote publisher negotiates the same asymmetric PTs (needed now that the
+   * snapshot holds value copies of the remote transceiver's PT fields). */
+  v2[0].payload_type = 120;
+  v2[0].rtx_payload_type = 121;
   strncpy(r2[0].cold->ufrag, "remoteUfrag2", sizeof(r2[0].cold->ufrag) - 1);
+  sync_mock_snapshot(&session2, a2, v2);
 
   /* Verify asymmetric video payload type negotiation (e.g., Firefox PT 120/121 overriding Chrome PT 96/97) */
   len = sfu_sdp_build_answer(&session2, SAMPLE_VIDEO_OFFER, strlen(SAMPLE_VIDEO_OFFER), "127.0.0.1", 17030, "XKrsH3xm", "dHkzP4aajGOJsWhquFzy3pxr",

--- a/tests/test_session_table.c
+++ b/tests/test_session_table.c
@@ -6,6 +6,7 @@
 
 #include <arpa/inet.h>
 #include <assert.h>
+#include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -19,7 +20,10 @@ static void make_addr(struct sockaddr_storage *addr, socklen_t *len, const char 
   *len = sizeof(struct sockaddr_in);
 }
 
-int main(void) {
+/* ---------------------------------------------------------------------------
+ * Single-threaded lifecycle tests
+ * ------------------------------------------------------------------------- */
+static void test_basic_lifecycle(void) {
   sfu_dtls_ctx_t dtls_ctx;
   assert(sfu_dtls_ctx_init(&dtls_ctx) == 0);
 
@@ -32,12 +36,13 @@ int main(void) {
   make_addr(&addr2, &len2, "127.0.0.1", 5002);
   make_addr(&addr3, &len3, "192.168.1.100", 6000);
 
-  /* 1. Create sessions */
+  /* Create sessions (each returns a caller pin). */
   sfu_peer_session_t *s1 = sfu_session_table_get_or_create(&table, &addr1, len1);
   assert(s1 != NULL);
   assert(s1->active == true);
+  assert(sfu_session_accepts_work(s1));
+  assert(atomic_load(&s1->lifecycle) == SFU_SESSION_LIFECYCLE_OPEN);
 
-  /* Fetching same address returns existing session */
   sfu_peer_session_t *s1_again = sfu_session_table_get_or_create(&table, &addr1, len1);
   assert(s1_again == s1);
 
@@ -45,58 +50,186 @@ int main(void) {
   assert(s2 != NULL);
   assert(s2 != s1);
 
-  /* 2. Lookup by address */
-  assert(sfu_session_table_find(&table, &addr1, len1) == s1);
-  assert(sfu_session_table_find(&table, &addr2, len2) == s2);
+  /* Lookup by address (acquired pins). */
+  sfu_peer_session_t *f;
+  f = sfu_session_table_find(&table, &addr1, len1);
+  assert(f == s1);
+  sfu_session_release(f);
+  f = sfu_session_table_find(&table, &addr2, len2);
+  assert(f == s2);
+  sfu_session_release(f);
   assert(sfu_session_table_find(&table, &addr3, len3) == NULL);
 
-  /* 3. Index & Lookup by ufrag */
+  /* Index & lookup by ufrag. */
   strncpy(s1->cold->ufrag, "ufrag_alice", sizeof(s1->cold->ufrag) - 1);
-  sfu_session_table_index_ufrag(&table, s1);
+  assert(sfu_session_table_index_ufrag(&table, s1));
 
   strncpy(s2->cold->ufrag, "ufrag_bob", sizeof(s2->cold->ufrag) - 1);
-  sfu_session_table_index_ufrag(&table, s2);
+  assert(sfu_session_table_index_ufrag(&table, s2));
 
-  assert(sfu_session_table_find_by_ufrag(&table, "ufrag_alice") == s1);
-  assert(sfu_session_table_find_by_ufrag(&table, "ufrag_bob") == s2);
+  f = sfu_session_table_find_by_ufrag(&table, "ufrag_alice");
+  assert(f == s1);
+  sfu_session_release(f);
+  f = sfu_session_table_find_by_ufrag(&table, "ufrag_bob");
+  assert(f == s2);
+  sfu_session_release(f);
   assert(sfu_session_table_find_by_ufrag(&table, "ufrag_charlie") == NULL);
 
-  /* 4. Rebind address */
-  sfu_session_table_rebind_addr(&table, s1, &addr3, len3);
+  /* Rebind address. */
+  assert(sfu_session_table_rebind_addr(&table, s1, &addr3, len3));
   assert(sfu_session_table_find(&table, &addr1, len1) == NULL);
-  assert(sfu_session_table_find(&table, &addr3, len3) == s1);
+  f = sfu_session_table_find(&table, &addr3, len3);
+  assert(f == s1);
+  sfu_session_release(f);
 
-  /* 5. Remove session & tombstone checks */
-  s1->receivers = SFU_CALLOC(2, sizeof(*s1->receivers));
-  assert(s1->receivers != NULL);
-  s1->receiver_capacity = 2;
-  s1->receivers[0] = SFU_CALLOC(1, sizeof(*s1->receivers[0]));
-  assert(s1->receivers[0] != NULL);
-  s1->receivers[1] = SFU_CALLOC(1, sizeof(*s1->receivers[1]));
-  assert(s1->receivers[1] != NULL);
+  /* Close s1: first transition is effective, repeats are idempotent. */
+  assert(sfu_session_begin_close(&table, s1));
+  assert(!sfu_session_begin_close(&table, s1));
+  assert(!sfu_session_accepts_work(s1));
+  assert(atomic_load(&s1->lifecycle) == SFU_SESSION_LIFECYCLE_CLOSING);
+  /* active stays true through logical close so teardown can destroy DTLS. */
+  assert(s1->active == true);
 
-  s2->receivers = SFU_CALLOC(3, sizeof(*s2->receivers));
-  assert(s2->receivers != NULL);
-  s2->receiver_capacity = 3;
-  s2->receivers[0] = SFU_CALLOC(1, sizeof(*s2->receivers[0]));
-  assert(s2->receivers[0] != NULL);
-  s2->receivers[1] = SFU_CALLOC(1, sizeof(*s2->receivers[1]));
-  assert(s2->receivers[1] != NULL);
-  s2->receivers[2] = SFU_CALLOC(1, sizeof(*s2->receivers[2]));
-  assert(s2->receivers[2] != NULL);
+  /* Acquired pointer remains fully usable after begin_close. */
+  assert(s1->cold != NULL);
+  assert(s1->cold->addr_len == len3);
 
-  sfu_session_table_remove(&table, s1);
+  /* Lookup-after-close returns NULL. */
   assert(sfu_session_table_find(&table, &addr3, len3) == NULL);
   assert(sfu_session_table_find_by_ufrag(&table, "ufrag_alice") == NULL);
 
-  /* Ensure s2 is unaffected */
-  assert(sfu_session_table_find(&table, &addr2, len2) == s2);
-  assert(sfu_session_table_find_by_ufrag(&table, "ufrag_bob") == s2);
+  /* s2 unaffected. */
+  f = sfu_session_table_find(&table, &addr2, len2);
+  assert(f == s2);
+  sfu_session_release(f);
+  f = sfu_session_table_find_by_ufrag(&table, "ufrag_bob");
+  assert(f == s2);
+  sfu_session_release(f);
+
+  /* Closing/nonmember rebind+index are rejected. */
+  assert(!sfu_session_table_rebind_addr(&table, s1, &addr1, len1));
+  assert(!sfu_session_table_index_ufrag(&table, s1));
+
+  /* Hole reuse: a new create reuses s1's cleared slot (count must not grow
+   * past the high-water mark of 2). */
+  uint32_t count_before = table.count;
+  sfu_peer_session_t *s3 = sfu_session_table_get_or_create(&table, &addr1, len1);
+  assert(s3 != NULL);
+  assert(s3 != s1);
+  assert(table.count == count_before);
+
+  /* Release caller pins; s1's final release frees it exactly once (the table
+   * ref was already dropped by begin_close). */
+  sfu_session_release(s1_again);
+  sfu_session_release(s1);
+  sfu_session_release(s3);
+  sfu_session_release(s2);
 
   sfu_session_table_destroy(&table);
   sfu_dtls_ctx_destroy(&dtls_ctx);
+}
 
-  /* 6. Routing table tests */
+/* Failed construction (invalid address) leaves no slot, no hole, no hash. */
+static void test_failed_construction(void) {
+  sfu_dtls_ctx_t dtls_ctx;
+  assert(sfu_dtls_ctx_init(&dtls_ctx) == 0);
+
+  sfu_session_table_t table;
+  assert(sfu_session_table_init(&table, &dtls_ctx) == 0);
+
+  struct sockaddr_storage addr1;
+  socklen_t len1;
+  make_addr(&addr1, &len1, "127.0.0.1", 5001);
+
+  assert(sfu_session_table_get_or_create(&table, NULL, 0) == NULL);
+  assert(sfu_session_table_get_or_create(&table, &addr1, 0) == NULL);
+  assert(sfu_session_table_get_or_create(&table, &addr1, sizeof(addr1) + 1) == NULL);
+  assert(table.count == 0);
+  assert(sfu_session_table_find(&table, &addr1, len1) == NULL);
+
+  sfu_session_table_destroy(&table);
+  sfu_dtls_ctx_destroy(&dtls_ctx);
+}
+
+/* ---------------------------------------------------------------------------
+ * Concurrent find-acquire vs begin_close (TSan target)
+ * ------------------------------------------------------------------------- */
+
+#define RACE_ITERS 200
+#define RACE_READERS 4
+
+typedef struct {
+  sfu_session_table_t *table;
+  struct sockaddr_storage addr;
+  socklen_t addr_len;
+  pthread_barrier_t barrier;
+  volatile uint64_t acquired_ok;
+} race_ctx_t;
+
+static void *race_reader(void *arg) {
+  race_ctx_t *ctx = arg;
+  pthread_barrier_wait(&ctx->barrier);
+  uint64_t ok = 0;
+  for (int i = 0; i < RACE_ITERS; i++) {
+    sfu_peer_session_t *s = sfu_session_table_find(ctx->table, &ctx->addr, ctx->addr_len);
+    if (s) {
+      /* Acquired pin must be usable even if begin_close races us. */
+      assert(s->cold != NULL);
+      assert(s->cold->addr_len == ctx->addr_len);
+      sfu_session_release(s);
+      ok++;
+    }
+  }
+  __atomic_fetch_add(&ctx->acquired_ok, ok, __ATOMIC_RELAXED);
+  return NULL;
+}
+
+static void test_concurrent_find_vs_close(void) {
+  sfu_dtls_ctx_t dtls_ctx;
+  assert(sfu_dtls_ctx_init(&dtls_ctx) == 0);
+
+  sfu_session_table_t table;
+  assert(sfu_session_table_init(&table, &dtls_ctx) == 0);
+
+  race_ctx_t ctx;
+  memset(&ctx, 0, sizeof(ctx));
+  ctx.table = &table;
+  make_addr(&ctx.addr, &ctx.addr_len, "10.0.0.1", 7000);
+  pthread_barrier_init(&ctx.barrier, NULL, RACE_READERS + 1);
+
+  sfu_peer_session_t *s = sfu_session_table_get_or_create(&table, &ctx.addr, ctx.addr_len);
+  assert(s != NULL);
+
+  pthread_t readers[RACE_READERS];
+  for (int i = 0; i < RACE_READERS; i++) {
+    assert(pthread_create(&readers[i], NULL, race_reader, &ctx) == 0);
+  }
+
+  pthread_barrier_wait(&ctx.barrier);
+  /* Let readers acquire some pins, then close concurrently with the remaining
+   * lookups; only one transition wins. */
+  for (volatile int spin = 0; spin < 100000; spin++) {
+  }
+  assert(sfu_session_begin_close(&table, s));
+  assert(!sfu_session_begin_close(&table, s));
+
+  for (int i = 0; i < RACE_READERS; i++) {
+    pthread_join(readers[i], NULL);
+  }
+
+  assert(ctx.acquired_ok > 0); /* readers did acquire pins before/around close */
+  assert(sfu_session_table_find(&table, &ctx.addr, ctx.addr_len) == NULL);
+
+  sfu_session_release(s); /* caller pin */
+  pthread_barrier_destroy(&ctx.barrier);
+  sfu_session_table_destroy(&table);
+  sfu_dtls_ctx_destroy(&dtls_ctx);
+}
+
+/* ---------------------------------------------------------------------------
+ * Routing table tests (unchanged behavior)
+ * ------------------------------------------------------------------------- */
+static void test_routing_table(void) {
   sfu_routing_table_t rtable;
   assert(sfu_routing_table_init(&rtable) == 0);
 
@@ -108,13 +241,18 @@ int main(void) {
 
   sfu_routing_table_set_pending_answer(&rtable, "ufrag_bob", 111, 222, 333, 96, 97);
 
-  /* Unregister by fd */
   sfu_routing_table_unregister_fd(&rtable, 10);
-  /* Verify entry with fd 10 was removed */
   assert(rtable.count == 1);
   assert(strcmp(rtable.entries[0].ufrag, "ufrag_eve") == 0);
 
   sfu_routing_table_destroy(&rtable);
+}
+
+int main(void) {
+  test_basic_lifecycle();
+  test_failed_construction();
+  test_concurrent_find_vs_close();
+  test_routing_table();
 
   printf("test_session_table: OK\n");
   return 0;

--- a/tests/test_worker_protocol.c
+++ b/tests/test_worker_protocol.c
@@ -188,6 +188,7 @@ static void fixture_destroy(fixture_t *f) {
   sfu_rtx_cache_destroy(f->cache);
   SFU_FREE(f->cache);
   f->session->rtx_cache = NULL; /* table teardown must not double-free */
+  sfu_session_release(f->session);   /* drop the caller pin from get_or_create */
   sfu_session_table_destroy(&f->sessions); /* destroys copied SRTP handles */
   f->srtp.inbound = NULL;
   f->srtp.outbound = NULL;


### PR DESCRIPTION
## Summary

Phase 3 of the security remediation series. Fixes the most critical lifetime defects identified in the review: session use-after-free (F-01), receiver pointer/capacity OOB (F-03), and in-place receiver slot races (F-04).

Depends on PR #72 (Phase 2 worker protocol integration). Should be merged after it.

### Session lifetime (F-01)

- Sessions are refcounted (`_Atomic refcount`, lifecycle OPEN/CLOSING, `accepts_work`).
- The table holds one ref from publish until close; every lookup/create returns a caller pin released via `sfu_session_release`.
- `get_or_create` publishes into the table + addr hash only after all fallible init (RTX cache, DTLS) succeeds; construction failure leaves no slot, hole, or hash entry.
- Table create reuses the first NULL hole.
- `sfu_session_begin_close`: idempotent OPEN→CLOSING transition under the table lock (accepts_work=false, removes addr+ufrag hash entries by member index, clears the slot), then detaches the room exactly once and drops the table ref. `active` stays true through logical close so final teardown always destroys initialized DTLS/SRTP state.
- `rebind_addr` / `index_ufrag` return bool and reject closing or non-member sessions; old hash entries removed by member index before replace.
- `table_destroy` force-closes remaining sessions (documented: requires no concurrent users).
- Worker sender pin covers the full packet path.
- Signaling drops the borrowed `c->session` pointer; answer and close use fresh acquired ufrag lookups released in the same callback.

### Receiver snapshots (F-03/F-04)

- `session->receivers` is now `_Atomic(sfu_receiver_snapshot_t *)`.
- Snapshots are immutable, refcounted, copy-on-write; each entry holds a retained destination session plus value-copied routing metadata (no mutable transceiver chains).
- `room_add_peer` / `room_remove_peer` build fully-populated replacements under the room lock; allocation failure leaves the old snapshot untouched.
- MID numbers are stable across replacements for surviving destinations; closing peers are never wired as routing destinations.
- Readers retain snapshots via CAS on the refcount (skipping snapshots draining to zero), traverse coherent entries whose subscribers are themselves retained, and release.
- Old snapshots stay valid until the last reader releases them.

### SDP

- Both builders acquire the snapshot once and read through a value view struct, so a single build is coherent.

## Test plan

- **Debug: 23/23 passed** (including `test_sdp`, which is now fixed as a side effect of the snapshot model).
- **ASan/UBSan: 23/23 passed.**
- **TSan: 23/23 passed** (race tests stressed 60x clean).
- New tests: session table lifecycle (pin usable after begin_close, idempotent close, lookup-after-close NULL, hole reuse, failed construction leaves no trace, closing/nonmember rebind+index rejected), receiver snapshot semantics (hold across replacement, generation bump, MID stability, alloc-failure safety), barriered concurrent find-vs-close and snapshot-read-vs-writer races.

## Not included yet

- Stream-scoped RTX cache and Media-SSRC → publisher routing.
- Per-source keyframe arbitration.
- SVC/scheduler split.
- TWCC/GCC rewrite.