### PR TITLE
Fix receiver-snapshot UAF; add churn + source-switch interleaving tests (#86)

### DIFF
--- a/src/room/room_media_graph.c
+++ b/src/room/room_media_graph.c
@@ -51,16 +51,26 @@ static sfu_receiver_snapshot_t *snapshot_alloc(uint32_t capacity) {
 /* Builds "old snapshot + dst appended". MID numbers are preserved across
  * replacements for SDP stability; a brand-new destination consumes fresh MIDs
  * from the owner's counter. Returns NULL on allocation failure, leaving the
- * peer's published snapshot unchanged. Call with the room lock held. */
+ * peer's published snapshot unchanged. Call with the room lock held.
+ *
+ * The room lock serializes writers, NOT readers: a concurrent reader can
+ * still hold (or be releasing) the old snapshot, so the old snapshot must be
+ * retained with sfu_session_receivers_acquire before its entries are read.
+ * Without the retain there is a use-after-free window: the writer loads the
+ * pointer, the last reader releases and frees it, the writer then reads
+ * old->count/old->entries (found by the #86 churn stress test under TSan as
+ * an allocator-recycle race). */
 static sfu_receiver_snapshot_t *snapshot_build_with(sfu_peer_session_t *owner, sfu_peer_session_t *dst) {
-  sfu_receiver_snapshot_t *old = atomic_load_explicit(&owner->receivers, memory_order_acquire);
+  sfu_receiver_snapshot_t *old = sfu_session_receivers_acquire(owner);
   if (snapshot_find(old, dst) != UINT32_MAX) {
+    sfu_receiver_snapshot_release(old);
     return NULL; /* already routed */
   }
 
   uint32_t old_count = old ? old->count : 0;
   sfu_receiver_snapshot_t *snap = snapshot_alloc(old_count + 1);
   if (!snap) {
+    sfu_receiver_snapshot_release(old);
     return NULL;
   }
   snap->generation = (old ? old->generation : 0) + 1;
@@ -81,22 +91,26 @@ static sfu_receiver_snapshot_t *snapshot_build_with(sfu_peer_session_t *owner, s
   e->has_video = true;
 
   snap->count = old_count + 1;
+  sfu_receiver_snapshot_release(old);
   return snap;
 }
 
 /* Builds "old snapshot minus dst". Slot positions and MID numbers of all
  * remaining destinations are preserved. Returns NULL on allocation failure,
- * leaving the peer's published snapshot unchanged. Call with room lock held. */
+ * leaving the peer's published snapshot unchanged. Call with room lock held.
+ * Retains the old snapshot for the same reason as snapshot_build_with. */
 static sfu_receiver_snapshot_t *snapshot_build_without(sfu_peer_session_t *owner, const sfu_peer_session_t *dst) {
-  sfu_receiver_snapshot_t *old = atomic_load_explicit(&owner->receivers, memory_order_acquire);
+  sfu_receiver_snapshot_t *old = sfu_session_receivers_acquire(owner);
   uint32_t pos = snapshot_find(old, dst);
   if (pos == UINT32_MAX) {
+    sfu_receiver_snapshot_release(old);
     return NULL; /* dst not routed to owner */
   }
 
   uint32_t old_count = old->count;
   sfu_receiver_snapshot_t *snap = snapshot_alloc(old_count - 1);
   if (!snap) {
+    sfu_receiver_snapshot_release(old);
     return NULL;
   }
   snap->generation = old->generation + 1;
@@ -111,6 +125,7 @@ static sfu_receiver_snapshot_t *snapshot_build_without(sfu_peer_session_t *owner
     out++;
   }
   snap->count = out;
+  sfu_receiver_snapshot_release(old);
   return snap;
 }
 

--- a/tests/fuzz/build_fuzz.sh
+++ b/tests/fuzz/build_fuzz.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# Build the libFuzzer parser harness (#86). Requires clang with the fuzzer
+# sanitizer; run in CI's sanitizer job or locally with clang installed.
+#
+# Usage: tests/fuzz/build_fuzz.sh [output-dir]
+# Then run:  <out>/fuzz_parsers -max_total_time=600 corpus/ artifacts/
+set -eu
+
+OUT="${1:-build-fuzz}"
+mkdir -p "$OUT"
+
+CFLAGS="-fsanitize=fuzzer,address,undefined -fno-omit-frame-pointer -g -O1 -I include -I src"
+
+# Only the pure parser translation units — no I/O, no threading, no uring.
+SRCS="
+  src/congestion/twcc_parser.c
+  src/congestion/gcc.c
+  src/media/svc/vp9_parser.c
+  src/rtcp/rtcp_compound.c
+  src/rtcp/rtcp_fb.c
+  src/rtp/rtp_ext.c
+  src/rtp/rtp_packet.c
+  src/rtp/rtx.c
+  src/rtp/rtx_build.c
+  tests/fuzz/fuzz_parsers.c
+"
+
+# shellcheck disable=SC2086
+clang $CFLAGS $SRCS -lm -o "$OUT/fuzz_parsers"
+echo "built $OUT/fuzz_parsers"

--- a/tests/fuzz/fuzz_parsers.c
+++ b/tests/fuzz/fuzz_parsers.c
@@ -1,0 +1,102 @@
+/* libFuzzer entry point for the wire parsers (#86).
+ *
+ * One harness, five parsers, dispatched on the first byte of input so a
+ * single corpus serves all of them (the standard "fuzz target router"
+ * pattern; keeps `make fuzz` to one binary):
+ *
+ *   0 -> compound RTCP iterator
+ *   1 -> TWCC feedback parser (drives the estimator-facing contract)
+ *   2 -> NACK FCI parser
+ *   3 -> RTP header-extension TWCC writer (mutable buffer, growth path)
+ *   4 -> VP9 payload descriptor parser
+ *
+ * Build (requires clang with -fsanitize=fuzzer):
+ *   clang -fsanitize=fuzzer,address,undefined -I include -I src \
+ *       tests/fuzz/fuzz_parsers.c <parser objects> -o fuzz_parsers
+ *
+ * The parsers are pure (no I/O, no allocation beyond the caller's stack),
+ * so this target is safe to run at full speed for days. Any crash input is
+ * a security bug: every byte here is attacker-controlled off the wire.
+ *
+ * This file is intentionally NOT wired into the default CTest build — it
+ * needs clang + libFuzzer, which CI provides in the sanitizer job. It is
+ * compiled by tests/fuzz/build_fuzz.sh. */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "congestion/twcc_parser.h"
+#include "media/svc/vp9_parser.h"
+#include "rtcp/rtcp_compound.h"
+#include "rtp/rtp_ext.h"
+#include "rtp/rtx.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  if (size < 2) {
+    return 0;
+  }
+  uint8_t which = data[0] % 5;
+  const uint8_t *d = data + 1;
+  size_t len = size - 1;
+
+  switch (which) {
+    case 0: {
+      sfu_rtcp_compound_iter it;
+      sfu_rtcp_compound_iter_init(&it, d, len);
+      sfu_rtcp_member_view view;
+      size_t guard = 0;
+      while (sfu_rtcp_compound_iter_next(&it, &view) == SFU_RTCP_COMPOUND_ITEM) {
+        if (++guard > 4096) {
+          __builtin_trap(); /* iterator must terminate on its own */
+        }
+      }
+      break;
+    }
+    case 1: {
+      sfu_twcc_parser_t p;
+      if (sfu_twcc_parser_init(&p, d, len, 0) != 0) {
+        break;
+      }
+      gcc_packet_info_t item;
+      size_t guard = 0;
+      while (sfu_twcc_parser_next(&p, &item)) {
+        if (++guard > 65536) {
+          __builtin_trap();
+        }
+      }
+      break;
+    }
+    case 2: {
+      sfu_nack_parser_t p;
+      if (!sfu_nack_parser_init(&p, d, len)) {
+        break;
+      }
+      uint16_t seq;
+      size_t guard = 0;
+      while (sfu_nack_parser_next(&p, &seq)) {
+        if (++guard > 65536) {
+          __builtin_trap();
+        }
+      }
+      break;
+    }
+    case 3: {
+      /* The writer grows the buffer in place; give it full capacity. */
+      if (len > 1024) {
+        break;
+      }
+      uint8_t buf[2048];
+      memcpy(buf, d, len);
+      size_t io_len = len;
+      (void)sfu_rtp_ext_write_twcc(buf, len, sizeof(buf), 5, 0x1234, &io_len);
+      break;
+    }
+    case 4: {
+      sfu_vp9_descriptor_t desc;
+      (void)sfu_parse_vp9_descriptor(d, len, &desc);
+      break;
+    }
+  }
+  return 0;
+}

--- a/tests/test_epoch_reclaimer.c
+++ b/tests/test_epoch_reclaimer.c
@@ -76,6 +76,35 @@ int main(void) {
   sfu_epoch_reclaimer_destroy_after_quiescence(&r);
   assert(atomic_load(&destroyed) == 50000); /* every retired ptr freed once */
 
+  /* #86: forced pool exhaustion with a permanently stalled worker. The
+   * retire side must apply backpressure (return false) forever — sweeps
+   * can never reclaim while one worker's generation never advances, and
+   * no record may be destroyed early or twice. The final quiescent drain
+   * frees exactly the retired set. */
+  atomic_store(&destroyed, 0);
+  assert(sfu_epoch_reclaimer_init(&r, 2, generation, &epochs) == 0);
+
+  uint32_t retired_count = 0;
+  size_t live = 0;
+  for (uint32_t i = 0; i < SFU_EPOCH_RECLAIMER_CAPACITY * 4; i++) {
+    void *ptr = malloc(1);
+    if (sfu_epoch_reclaimer_retire(&r, ptr, destroy)) {
+      retired_count++;
+    } else {
+      free(ptr); /* backpressure: caller keeps and disposes */
+      live++;
+    }
+    /* Only worker 0 advances; worker 1 is stalled for the whole loop. */
+    atomic_fetch_add(&epochs.generations[0], 1);
+    sfu_epoch_reclaimer_sweep(&r);
+  }
+  assert(retired_count == SFU_EPOCH_RECLAIMER_CAPACITY);
+  assert(live == SFU_EPOCH_RECLAIMER_CAPACITY * 3);
+  assert(atomic_load(&destroyed) == 0); /* nothing reclaimable while stalled */
+
+  sfu_epoch_reclaimer_destroy_after_quiescence(&r);
+  assert(atomic_load(&destroyed) == SFU_EPOCH_RECLAIMER_CAPACITY);
+
   printf("test_epoch_reclaimer: OK\n");
   return 0;
 }

--- a/tests/test_room.c
+++ b/tests/test_room.c
@@ -1,5 +1,7 @@
 #include <assert.h>
 #include <pthread.h>
+#include <stdatomic.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -243,10 +245,105 @@ static void test_concurrent_snapshot_read_write(void) {
   sfu_room_destroy(&room);
 }
 
+/* #86: multi-publisher room churn — one stable subscriber, several
+ * publisher threads concurrently add/remove themselves while a reader
+ * thread continuously acquires each publisher's receiver snapshot and
+ * dereferences every entry (the forwarding hot path's access pattern).
+ * Under TSan this witnesses the copy-on-write snapshot contract: entries
+ * are always coherent (retained, non-NULL) no matter how replacement
+ * interleaves with reads. */
+typedef struct {
+  sfu_room_t *room;
+  sfu_peer_session_t **publishers;
+  uint32_t publisher_count;
+  sfu_peer_session_t *subscriber;
+  pthread_barrier_t barrier;
+} churn_ctx_t;
+
+static void *churn_writer(void *arg) {
+  churn_ctx_t *ctx = arg;
+  /* Each writer owns exactly one publisher slot, assigned atomically. */
+  static _Atomic intptr_t next_slot;
+  intptr_t idx = atomic_fetch_add_explicit(&next_slot, 1, memory_order_relaxed);
+
+  sfu_scheduler_t scheduler = {0};
+  pthread_barrier_wait(&ctx->barrier);
+  for (int i = 0; i < 100; i++) {
+    room_add_peer(ctx->room, ctx->publishers[idx], &scheduler);
+    room_remove_peer(ctx->room, ctx->publishers[idx]);
+  }
+  return NULL;
+}
+
+static void *churn_reader(void *arg) {
+  churn_ctx_t *ctx = arg;
+  pthread_barrier_wait(&ctx->barrier);
+  for (int i = 0; i < 2000; i++) {
+    sfu_peer_session_t *pub = ctx->publishers[i % ctx->publisher_count];
+    sfu_receiver_snapshot_t *snap = sfu_session_receivers_acquire(pub);
+    if (snap) {
+      for (uint32_t e = 0; e < snap->count; e++) {
+        /* Coherence: retained subscriber with valid cold, even mid-churn. */
+        assert(snap->entries[e].subscriber != NULL);
+        assert(snap->entries[e].subscriber->cold != NULL);
+      }
+      sfu_receiver_snapshot_release(snap);
+    }
+  }
+  return NULL;
+}
+
+static void test_multi_publisher_concurrent_churn(void) {
+  enum { PUBS = 4, WRITERS = PUBS, READERS = 2 };
+  sfu_room_t room;
+  assert(sfu_room_init(&room, 9) == 0);
+
+  sfu_peer_session_t *pubs[PUBS];
+  for (int i = 0; i < PUBS; i++) {
+    char name[16];
+    snprintf(name, sizeof(name), "pub%d", i);
+    pubs[i] = mock_session(name);
+  }
+  sfu_peer_session_t *sub = mock_session("sub");
+
+  sfu_scheduler_t scheduler = {0};
+  room_add_peer(&room, sub, &scheduler);
+
+  churn_ctx_t ctx = {
+      .room = &room, .publishers = pubs, .publisher_count = PUBS, .subscriber = sub,
+  };
+  pthread_barrier_init(&ctx.barrier, NULL, WRITERS + READERS);
+
+  pthread_t writers[WRITERS], readers[READERS];
+  for (int i = 0; i < WRITERS; i++) {
+    assert(pthread_create(&writers[i], NULL, churn_writer, &ctx) == 0);
+  }
+  for (int i = 0; i < READERS; i++) {
+    assert(pthread_create(&readers[i], NULL, churn_reader, &ctx) == 0);
+  }
+  for (int i = 0; i < WRITERS; i++) {
+    pthread_join(writers[i], NULL);
+  }
+  for (int i = 0; i < READERS; i++) {
+    pthread_join(readers[i], NULL);
+  }
+  pthread_barrier_destroy(&ctx.barrier);
+
+  /* All publishers flapped out; the subscriber's view of the room is
+   * itself only, and each publisher has no receivers left. */
+  for (int i = 0; i < PUBS; i++) {
+    assert(receiver_count(pubs[i]) == 0);
+    sfu_session_release(pubs[i]);
+  }
+  sfu_session_release(sub);
+  sfu_room_destroy(&room);
+}
+
 int main(void) {
   test_add_remove();
   test_snapshot_hold_across_replace();
   test_concurrent_snapshot_read_write();
+  test_multi_publisher_concurrent_churn();
 
   printf("test_room: OK\n");
   return 0;

--- a/tests/test_valkey_queue.c
+++ b/tests/test_valkey_queue.c
@@ -131,11 +131,72 @@ static void test_public_wraparound(void) {
   valkey_queue_destroy_after_producers_stopped(&queue);
 }
 
+/* #86: producers racing valkey_queue_close — the shutdown interleaving.
+ * Producers must see exactly one of OK (item queued, drained later),
+ * FULL (saturation backpressure), or CLOSED; every accepted item must be
+ * accounted exactly once between drain and dispose, and every non-OK item
+ * stays with the producer (freed here). Under TSan this witnesses the
+ * close-vs-post mutex contract. */
+typedef struct {
+  valkey_queue_t *queue;
+  size_t accepted;
+  size_t rejected; /* FULL or CLOSED: ownership stayed with producer */
+} race_producer_t;
+
+static void *produce_until_closed(void *arg) {
+  race_producer_t *p = arg;
+  for (size_t i = 0; i < 2000; i++) {
+    void *item = new_item();
+    valkey_queue_post_result_t rc = valkey_queue_post(p->queue, item);
+    if (rc == VALKEY_QUEUE_OK) {
+      p->accepted++;
+    } else {
+      assert(rc == VALKEY_QUEUE_FULL || rc == VALKEY_QUEUE_CLOSED);
+      free(item);
+      p->rejected++;
+    }
+  }
+  return NULL;
+}
+
+static void test_producer_close_race(void) {
+  test_stats_t stats = {0};
+  valkey_queue_t queue;
+  assert(valkey_queue_init(&queue, dispose_pending, &stats) == 0);
+
+  race_producer_t producers[4] = {0};
+  pthread_t threads[4];
+  for (size_t i = 0; i < 4; i++) {
+    producers[i].queue = &queue;
+    assert(pthread_create(&threads[i], NULL, produce_until_closed, &producers[i]) == 0);
+  }
+  /* Close concurrently with the producer storm. */
+  valkey_queue_close(&queue);
+  for (size_t i = 0; i < 4; i++) {
+    pthread_join(threads[i], NULL);
+  }
+
+  size_t accepted = 0;
+  for (size_t i = 0; i < 4; i++) {
+    accepted += producers[i].accepted;
+    assert(producers[i].accepted + producers[i].rejected == 2000);
+  }
+  assert(accepted <= VALKEY_QUEUE_CAPACITY);
+
+  /* Every accepted item is accounted exactly once: drained now, or
+   * disposed at destroy. No leak, no double-free. */
+  size_t drained = valkey_queue_drain(&queue, consume_item, &stats);
+  valkey_queue_destroy_after_producers_stopped(&queue);
+  assert(atomic_load(&stats.consumed) == drained);
+  assert(drained + atomic_load(&stats.disposed) == accepted);
+}
+
 int main(void) {
   test_invalid_arguments();
   test_capacity_and_drain();
   test_concurrent_producers();
   test_close_and_pending();
   test_public_wraparound();
+  test_producer_close_race();
   return 0;
 }

--- a/tests/test_worker_protocol.c
+++ b/tests/test_worker_protocol.c
@@ -904,6 +904,62 @@ static void test_forward_churn_subscriber_disconnect(void) {
   kf_fixture_destroy(&f);
 }
 
+/* #82 acceptance interleaving (#86): source switch with COLLIDING sequence
+ * numbers and a delayed NACK. Publisher A's seq 42 is cached at generation
+ * 0; the source switches (generation bumps); publisher B's stream reuses
+ * seq 42; a delayed NACK for A's seq 42 arrives BEFORE B's 42 is cached.
+ * It must miss (stale generation) and trigger a keyframe — never serve
+ * A's media after the switch. Then B's 42 lands and a fresh NACK is served
+ * from B's entry at the new generation. */
+static void test_source_switch_colliding_seq_delayed_nack(void) {
+  fixture_t f;
+  fixture_init(&f);
+
+  uint8_t pkt_buf[512];
+  size_t pkt_len;
+  /* Publisher A's stream: MEDIA_SSRC, generation 0, seq 42. */
+  build_rtp_video(pkt_buf, 42, 100, &pkt_len);
+  pkt_buf[12] = 0xaa; /* A's payload marker */
+  sfu_rtx_cache_put_stream(f.cache, 42, pkt_buf, (uint32_t)pkt_len, RTX_SSRC, RTX_PT, MEDIA_SSRC, 0);
+
+  /* Source switch: generation 0 -> 1 (sfu_layer_selector_switch_source
+   * bumps this; the new source's stream here reuses the same media SSRC,
+   * so ONLY the generation distinguishes stale from fresh). */
+  atomic_store(&f.session->egress_generation, 1);
+
+  /* Delayed NACK for seq 42 arrives before the new source's 42 is cached:
+   * stale entry must miss -> keyframe fallback, no retransmission. */
+  uint8_t nack[64];
+  size_t nack_len = build_nack(nack, (uint16_t[]){42, 0x0000}, 2);
+  feed_rtcp(&f, nack, nack_len);
+  assert(f.cache->next_rtx_seq == 0);    /* nothing served from stale gen */
+  assert(f.session->last_pli_time != 0); /* miss -> keyframe requested */
+
+  /* New source's seq 42 arrives (colliding sequence number) and is cached
+   * at generation 1 with a different payload. */
+  build_rtp_video(pkt_buf, 42, 100, &pkt_len);
+  pkt_buf[12] = 0xbb; /* B's payload marker */
+  sfu_rtx_cache_put_stream(f.cache, 42, pkt_buf, (uint32_t)pkt_len, RTX_SSRC, RTX_PT, MEDIA_SSRC, 1);
+
+  /* A fresh NACK for 42 is now served from B's entry — verify by the RTX
+   * sequence counter advancing and (through the cache read-back) that the
+   * served bytes are B's, not A's. */
+  f.session->last_pli_time = 0;
+  feed_rtcp(&f, nack, nack_len);
+  assert(f.cache->next_rtx_seq == 1);
+
+  uint8_t readback[512];
+  uint32_t rb_len = 0;
+  uint32_t rb_ssrc = 0;
+  uint8_t rb_pt = 0;
+  assert(sfu_rtx_cache_get_stream(f.cache, 42, readback, &rb_len, &rb_ssrc, &rb_pt, MEDIA_SSRC, 1));
+  assert(readback[12] == 0xbb); /* B's entry, not A's */
+  /* The same lookup at the OLD generation still misses. */
+  assert(!sfu_rtx_cache_get_stream(f.cache, 42, readback, &rb_len, &rb_ssrc, &rb_pt, MEDIA_SSRC, 0));
+
+  fixture_destroy(&f);
+}
+
 int main(void) {
   test_compound_nack_rtx_dispatch();
   test_compound_nack_then_pli();
@@ -925,6 +981,7 @@ int main(void) {
   test_egress_pacer_drops_enhancement_not_audio();
   test_nack_line_rate_throttled_by_rtx_budget();
   test_forward_churn_subscriber_disconnect();
+  test_source_switch_colliding_seq_delayed_nack();
   printf("test_worker_protocol: OK\n");
   return 0;
 }


### PR DESCRIPTION
## Summary

The remaining #86 stress work found a **real use-after-free** on the first run of the new churn test.

### The bug

`snapshot_build_with` / `snapshot_build_without` (room_media_graph.c) read the owner's current receiver snapshot **without retaining it**. The room lock serializes writers (the single-writer publish invariant), but not readers — a concurrent reader's final `sfu_receiver_snapshot_release` can free the snapshot between the writer's acquire-load and its reads of `old->count` / `old->entries`.

The new `test_multi_publisher_concurrent_churn` (4 publisher threads flapping add/remove ×100, 2 reader threads continuously acquiring snapshots) reproduces it under TSan within ~10 iterations, as an allocator-recycle race: mimalloc hands the freed block to the next `snapshot_alloc` whose `memset` collides with the first writer's reads. This matches the class of the TSan report seen-but-never-reproduced during the F-18 work.

### The fix

Both build functions now retain the old snapshot with `sfu_session_receivers_acquire` for the duration of the build and release it afterwards. Writer-vs-writer serialization is unchanged (room lock); the retain closes the writer-vs-last-reader window. Comments document why the room lock alone is insufficient.

### New tests (#86 checklist)

- `test_room`: multi-publisher concurrent churn (described above) — the reproducer, now clean over 40 TSan iterations.
- `test_worker_protocol`: **source switch with colliding sequence numbers + delayed NACK** — the #82 acceptance interleaving. Pre-switch seq 42 misses at the new generation (keyframe fallback, nothing retransmitted); the new source's colliding seq 42 is served from its own entry; old-generation lookups stay invisible.

### Verification

30/30 tests on normal, ASan, and TSan (`setarch -R ctest`) at HEAD; the churn test stressed 40× under TSan with zero reports after the fix.

Refs #86, #82.