### PR TITLE
fix(fanout): cross-worker KF request leaks, job pool partitioning, KF coalescing

### DIFF
--- a/src/peer/session.c
+++ b/src/peer/session.c
@@ -1,5 +1,6 @@
 #include "peer/session.h"
 #include <assert.h>
+#include <inttypes.h>
 #include <string.h>
 #include "congestion/gcc.h"
 #include "congestion/twcc_history.h"
@@ -8,6 +9,7 @@
 #include "rtp/rtx.h"
 #include "runtime/routing_context.h"
 #include "runtime/scheduler.h"
+#include "runtime/timer.h"
 #include "runtime/worker.h"
 #include "transport/dtls/dtls.h"
 #include "transport/srtp/srtp.h"
@@ -24,6 +26,10 @@ typedef struct {
   sfu_session_table_t *t;
   const char *ufrag;
 } ufrag_match_ctx_t;
+
+/* Mirrors SFU_WORKER_KF_THROTTLE_MS in runtime/worker.c: the request-side
+ * throttle lives there, the execution-side coalescing window lives here. */
+#define SFU_SESSION_KF_THROTTLE_MS 1000
 
 int sfu_session_table_init(sfu_session_table_t *t, sfu_dtls_ctx_t *dtls_ctx) {
   memset(t, 0, sizeof(*t));
@@ -542,11 +548,6 @@ void sfu_session_request_keyframe(sfu_worker_t *w, sfu_peer_session_t *publisher
     return;
   }
 
-  sfu_packet_t *rtcp_pkt = sfu_packet_pool_alloc(w->pp);
-  if (!rtcp_pkt) {
-    return;
-  }
-
   if (publisher->worker_id != w->worker_index) {
     SFU_LOG_INFO("[KF-DBG] Offloading KF request: current worker %u -> publisher worker %u (pub peer_id=%u)", w->worker_index, publisher->worker_id,
                  publisher->peer_id);
@@ -561,19 +562,40 @@ void sfu_session_request_keyframe(sfu_worker_t *w, sfu_peer_session_t *publisher
     return;
   }
 
-  SFU_LOG_INFO("Worker %u executing PLI output to publisher peer %u SSRC %u", w->worker_index, publisher->peer_id, publisher->uplink_video.ssrc);
-
-  int rtcp_len = 0;
-  uint32_t sfu_sender_ssrc = 1;
-
   uint32_t media_ssrc = publisher->uplink_video.ssrc;
 
   SFU_LOG_INFO("[KF-DBG] Executing KF request on owner worker %u for pub peer_id=%u (uplink SSRC=%u)", w->worker_index, publisher->peer_id, media_ssrc);
+
+  /* Execution-side coalescing: requests are throttled where they originate
+   * (sfu_worker_request_keyframe_throttled), but N subscribers each keep
+   * their own throttle state and can each hand a cross-worker job for the
+   * same publisher. Collapse them here so the publisher receives at most
+   * one PLI per throttle window no matter how many workers asked. */
+  int64_t now = (int64_t)sfu_now_ms();
+  if (publisher->last_pli_time != 0 && now - publisher->last_pli_time < SFU_SESSION_KF_THROTTLE_MS) {
+    SFU_LOG_DEBUG("worker %u: KF request for publisher %u coalesced (last PLI %" PRId64 " ms ago)", w->worker_index, publisher->peer_id,
+                  now - publisher->last_pli_time);
+    return;
+  }
+  publisher->last_pli_time = now;
 
   if (media_ssrc == 0) {
     SFU_LOG_WARN("[KF-DBG] Cannot send PLI/FIR: Publisher %u video SSRC is 0", publisher->peer_id);
     return;
   }
+
+  /* Allocate only after every no-packet branch above; anything allocated
+   * here is always released on the way out below. */
+  sfu_packet_t *rtcp_pkt = sfu_packet_pool_alloc(w->pp);
+  if (!rtcp_pkt) {
+    return;
+  }
+
+  SFU_LOG_INFO("Worker %u executing PLI output to publisher peer %u SSRC %u", w->worker_index, publisher->peer_id, publisher->uplink_video.ssrc);
+
+  int rtcp_len = 0;
+  uint32_t sfu_sender_ssrc = 1;
+
 
   if (use_fir) {
     rtcp_len = sfu_rtcp_build_fir(sfu_sender_ssrc, media_ssrc, &publisher->fir_seq, rtcp_pkt->data, rtcp_pkt->cap);

--- a/src/runtime/fanout.c
+++ b/src/runtime/fanout.c
@@ -1,10 +1,16 @@
 #include "runtime/fanout.h"
+#include "peer/session.h"
 #include "sfu/config.h"
 #include "util/alloc.h"
 #include "util/log.h"
 
 #include <stddef.h>
 #include <string.h>
+
+static uint32_t partition_capacity(uint32_t job_pool_capacity, uint32_t worker_count) {
+  uint32_t cap = job_pool_capacity / worker_count;
+  return cap > 0 ? cap : 1;
+}
 
 int sfu_fanout_mesh_init(sfu_fanout_mesh_t *mesh, uint32_t worker_count, uint32_t ring_capacity, uint32_t job_pool_capacity) {
   memset(mesh, 0, sizeof(*mesh));
@@ -15,17 +21,34 @@ int sfu_fanout_mesh_init(sfu_fanout_mesh_t *mesh, uint32_t worker_count, uint32_
   }
 
   mesh->worker_count = worker_count;
+  mesh->per_partition_capacity = partition_capacity(job_pool_capacity, worker_count);
 
-  if (sfu_pool_init(&mesh->job_pool, job_pool_capacity, sizeof(sfu_fanout_job_t)) != 0) {
-    SFU_LOG_ERROR("fanout mesh: failed to init job pool");
+  mesh->job_pools = SFU_CALLOC(worker_count, sizeof(sfu_pool_t));
+  if (!mesh->job_pools) {
+    SFU_LOG_ERROR("fanout mesh: failed to allocate job pool partitions");
     return -1;
+  }
+  for (uint32_t i = 0; i < worker_count; i++) {
+    if (sfu_pool_init(&mesh->job_pools[i], mesh->per_partition_capacity, sizeof(sfu_fanout_job_t)) != 0) {
+      SFU_LOG_ERROR("fanout mesh: failed to init job pool partition %u", i);
+      for (uint32_t j = 0; j < i; j++) {
+        sfu_pool_destroy(&mesh->job_pools[j]);
+      }
+      SFU_FREE(mesh->job_pools);
+      mesh->job_pools = NULL;
+      return -1;
+    }
   }
 
   uint32_t cell_count = worker_count * worker_count;
   mesh->rings = SFU_CALLOC(cell_count, sizeof(sfu_spsc_ring_t));
   if (!mesh->rings) {
     SFU_LOG_ERROR("fanout mesh: failed to allocate ring array");
-    sfu_pool_destroy(&mesh->job_pool);
+    for (uint32_t i = 0; i < worker_count; i++) {
+      sfu_pool_destroy(&mesh->job_pools[i]);
+    }
+    SFU_FREE(mesh->job_pools);
+    mesh->job_pools = NULL;
     return -1;
   }
 
@@ -36,12 +59,17 @@ int sfu_fanout_mesh_init(sfu_fanout_mesh_t *mesh, uint32_t worker_count, uint32_
         sfu_spsc_ring_destroy(&mesh->rings[j]);
       }
       SFU_FREE(mesh->rings);
-      sfu_pool_destroy(&mesh->job_pool);
+      mesh->rings = NULL;
+      for (uint32_t j = 0; j < worker_count; j++) {
+        sfu_pool_destroy(&mesh->job_pools[j]);
+      }
+      SFU_FREE(mesh->job_pools);
+      mesh->job_pools = NULL;
       return -1;
     }
   }
 
-  SFU_LOG_INFO("fanout mesh initialized: %u workers, %u rings, %u job slots", worker_count, cell_count, job_pool_capacity);
+  SFU_LOG_INFO("fanout mesh initialized: %u workers, %u rings, %u job slots per destination", worker_count, cell_count, mesh->per_partition_capacity);
   return 0;
 }
 
@@ -51,17 +79,33 @@ void sfu_fanout_mesh_destroy(sfu_fanout_mesh_t *mesh) {
     sfu_spsc_ring_destroy(&mesh->rings[i]);
   }
   SFU_FREE(mesh->rings);
-  sfu_pool_destroy(&mesh->job_pool);
+  if (mesh->job_pools) {
+    for (uint32_t i = 0; i < mesh->worker_count; i++) {
+      sfu_pool_destroy(&mesh->job_pools[i]);
+    }
+    SFU_FREE(mesh->job_pools);
+  }
 }
 
 static sfu_spsc_ring_t *mesh_ring(sfu_fanout_mesh_t *mesh, uint32_t src, uint32_t dst) { return &mesh->rings[src * mesh->worker_count + dst]; }
 
-bool sfu_fanout_mesh_enqueue(sfu_fanout_mesh_t *mesh, uint32_t src_worker, uint32_t dst_worker, sfu_packet_t *pkt, const struct sockaddr_storage *dst_addr,
-                             socklen_t dst_len) {
+static sfu_fanout_job_t *mesh_job_alloc(sfu_fanout_mesh_t *mesh, uint32_t src_worker, uint32_t dst_worker) {
   uint32_t job_idx;
-  sfu_fanout_job_t *job = sfu_pool_alloc(&mesh->job_pool, &job_idx);
+  sfu_fanout_job_t *job = sfu_pool_alloc(&mesh->job_pools[dst_worker], &job_idx);
   if (!job) {
     SFU_LOG_WARN("fanout mesh: job pool exhausted (worker %u -> %u)", src_worker, dst_worker);
+    return NULL;
+  }
+  memset(job, 0, sizeof(*job));
+  job->pool_index = job_idx;
+  job->pool_dst = dst_worker;
+  return job;
+}
+
+bool sfu_fanout_mesh_enqueue(sfu_fanout_mesh_t *mesh, uint32_t src_worker, uint32_t dst_worker, sfu_packet_t *pkt, const struct sockaddr_storage *dst_addr,
+                             socklen_t dst_len) {
+  sfu_fanout_job_t *job = mesh_job_alloc(mesh, src_worker, dst_worker);
+  if (!job) {
     return false;
   }
 
@@ -70,17 +114,11 @@ bool sfu_fanout_mesh_enqueue(sfu_fanout_mesh_t *mesh, uint32_t src_worker, uint3
   job->pkt = pkt;
   memcpy(&job->dst, dst_addr, dst_len);
   job->dst_len = dst_len;
-  job->subscriber = NULL;
   job->kind = SFU_FANOUT_JOB_READY;
-  job->has_video = false;
-  job->video_ssrc = 0;
-  job->video_rtx_ssrc = 0;
-  job->video_pt = 0;
-  job->video_rtx_pt = 0;
 
   if (!sfu_spsc_ring_push(mesh_ring(mesh, src_worker, dst_worker), job)) {
     SFU_LOG_WARN("fanout mesh: ring %u->%u full, dropping", src_worker, dst_worker);
-    sfu_pool_free(&mesh->job_pool, job_idx);
+    sfu_fanout_mesh_free_job(mesh, job);
     return false;
   }
 
@@ -90,10 +128,8 @@ bool sfu_fanout_mesh_enqueue(sfu_fanout_mesh_t *mesh, uint32_t src_worker, uint3
 bool sfu_fanout_mesh_enqueue_forward(sfu_fanout_mesh_t *mesh, uint32_t src_worker, uint32_t dst_worker, sfu_packet_t *pkt, sfu_peer_session_t *subscriber,
                                      const struct sockaddr_storage *dst_addr, socklen_t dst_len, uint32_t video_ssrc, uint32_t video_rtx_ssrc, uint8_t video_pt,
                                      uint8_t video_rtx_pt, bool has_video, bool is_audio, uint8_t pacer_class) {
-  uint32_t job_idx;
-  sfu_fanout_job_t *job = sfu_pool_alloc(&mesh->job_pool, &job_idx);
+  sfu_fanout_job_t *job = mesh_job_alloc(mesh, src_worker, dst_worker);
   if (!job) {
-    SFU_LOG_WARN("fanout mesh: job pool exhausted (worker %u -> %u)", src_worker, dst_worker);
     return false;
   }
 
@@ -112,7 +148,7 @@ bool sfu_fanout_mesh_enqueue_forward(sfu_fanout_mesh_t *mesh, uint32_t src_worke
 
   if (!sfu_spsc_ring_push(mesh_ring(mesh, src_worker, dst_worker), job)) {
     SFU_LOG_WARN("fanout mesh: ring %u->%u full, dropping", src_worker, dst_worker);
-    sfu_pool_free(&mesh->job_pool, job_idx);
+    sfu_fanout_mesh_free_job(mesh, job);
     return false;
   }
 
@@ -143,14 +179,11 @@ bool sfu_fanout_mesh_enqueue_keyframe_request(sfu_fanout_mesh_t *mesh, uint32_t 
     return false;
   }
 
-  uint32_t job_idx;
-  sfu_fanout_job_t *job = sfu_pool_alloc(&mesh->job_pool, &job_idx);
+  sfu_fanout_job_t *job = mesh_job_alloc(mesh, src_worker, dst_worker);
   if (!job) {
-    SFU_LOG_WARN("fanout mesh: job pool exhausted (worker %u -> %u)", src_worker, dst_worker);
     return false;
   }
 
-  memset(job, 0, sizeof(*job));
   job->kind = SFU_FANOUT_JOB_KEYFRAME_REQUEST;
   job->publisher = publisher;
 
@@ -158,7 +191,10 @@ bool sfu_fanout_mesh_enqueue_keyframe_request(sfu_fanout_mesh_t *mesh, uint32_t 
 
   if (!sfu_spsc_ring_push(mesh_ring(mesh, src_worker, dst_worker), job)) {
     SFU_LOG_WARN("fanout mesh: ring %u->%u full, dropping", src_worker, dst_worker);
-    sfu_pool_free(&mesh->job_pool, job_idx);
+    /* The retain above is owned by the queued job; if the job never makes
+     * it onto the ring, the reference must be dropped here. */
+    sfu_session_release(publisher);
+    sfu_fanout_mesh_free_job(mesh, job);
     return false;
   }
 
@@ -166,7 +202,5 @@ bool sfu_fanout_mesh_enqueue_keyframe_request(sfu_fanout_mesh_t *mesh, uint32_t 
 }
 
 void sfu_fanout_mesh_free_job(sfu_fanout_mesh_t *mesh, sfu_fanout_job_t *job) {
-  ptrdiff_t byte_off = (uint8_t *)job - mesh->job_pool.slab;
-  uint32_t index = (uint32_t)(byte_off / mesh->job_pool.slot_size);
-  sfu_pool_free(&mesh->job_pool, index);
+  sfu_pool_free(&mesh->job_pools[job->pool_dst], job->pool_index);
 }

--- a/src/runtime/fanout.h
+++ b/src/runtime/fanout.h
@@ -24,6 +24,8 @@ typedef struct sfu_fanout_job {
   sfu_peer_session_t *publisher;
   uint32_t video_ssrc;
   uint32_t video_rtx_ssrc;
+  uint32_t pool_index; /* index within mesh->job_pools[pool_dst] */
+  uint32_t pool_dst;   /* home partition: mesh->job_pools[pool_dst] owns this slot */
   uint8_t video_pt;
   uint8_t video_rtx_pt;
   bool has_video;
@@ -33,9 +35,15 @@ typedef struct sfu_fanout_job {
 } sfu_fanout_job_t;
 
 typedef struct sfu_fanout_mesh {
-  sfu_pool_t job_pool;
+  /* One job-pool partition per destination worker: a dst worker is the only
+   * thread freeing jobs addressed to it, so each partition's free list is
+   * only ever popped by its owner worker (the allocator) and pushed by
+   * that same worker on the free side of other cores' traffic -- the slab
+   * stays mostly on one core's cache instead of bouncing across all of them. */
+  sfu_pool_t *job_pools;
   sfu_spsc_ring_t *rings;
   uint32_t worker_count;
+  uint32_t per_partition_capacity;
 } sfu_fanout_mesh_t;
 
 typedef void (*sfu_fanout_job_fn)(void *user_data, sfu_fanout_job_t *job);

--- a/src/runtime/worker.c
+++ b/src/runtime/worker.c
@@ -81,8 +81,6 @@ static int sfu_rtp_get_payload_offset(const uint8_t *data, uint32_t len) {
 
 #define SFU_WORKER_NACK_REQUEST_CAP 48
 
-#define SFU_WORKER_KF_THROTTLE_MS 1000
-
 static void sfu_svc_update_layers(sfu_peer_session_t *session, uint32_t bitrate_bps) {
   sfu_pacer_set_rate(&session->pacer, bitrate_bps, (int64_t)sfu_now_us());
   if (!session->schedulers) {
@@ -136,22 +134,18 @@ static sfu_peer_session_t *sfu_worker_find_publisher_by_media_ssrc(sfu_peer_sess
 }
 
 static void sfu_worker_request_keyframe_throttled(sfu_worker_t *w, sfu_peer_session_t *publisher) {
-  int64_t now = (int64_t)sfu_now_ms();
-  if (now - publisher->last_pli_time < SFU_WORKER_KF_THROTTLE_MS) {
-    return;
-  }
-  publisher->last_pli_time = now;
-
   sfu_session_request_keyframe(w, publisher, false);
 }
 
 static void sfu_worker_request_source_keyframe(sfu_worker_t *w, sfu_peer_session_t *feedback_session, uint32_t media_ssrc) {
   sfu_peer_session_t *publisher = sfu_worker_find_publisher_by_media_ssrc(feedback_session, media_ssrc);
   if (!publisher) {
+    /* The feedback names an SSRC we cannot map to a room publisher (e.g.
+     * stale answer). Fall back to the sender of the feedback so a keyframe
+     * is still requested instead of being silently swallowed. */
     sfu_metric_inc("rtcp_kf_unresolved");
     publisher = feedback_session;
     atomic_fetch_add_explicit(&publisher->refcount, 1, memory_order_relaxed);
-    return;
   }
   sfu_worker_request_keyframe_throttled(w, publisher);
   sfu_session_release(publisher);

--- a/tests/test_fanout_mesh.c
+++ b/tests/test_fanout_mesh.c
@@ -67,15 +67,22 @@ int main(void) {
   drained = sfu_fanout_mesh_drain(&mesh, 0, 16, collect, &c);
   assert(drained == 0);
 
-  /* Job pool round-trips correctly: having freed every job drained
-   * above, we should be able to allocate the full pool capacity again
-   * without exhaustion. */
-  for (int i = 0; i < 64; i++) {
+  /* Job pool round-trips correctly: partitions are per destination worker
+   * (64 total / 4 workers = 16 slots per dst), so after freeing every job
+   * drained above, dst 1's partition must accept exactly 16 more jobs. */
+  for (int i = 0; i < 16; i++) {
     assert(sfu_fanout_mesh_enqueue(&mesh, 0, 1, &fake_pkt, &s1, sizeof(struct sockaddr_in)));
   }
+  /* 17th job for dst 1: partition exhausted -> enqueue fails cleanly. */
+  assert(!sfu_fanout_mesh_enqueue(&mesh, 0, 1, &fake_pkt, &s1, sizeof(struct sockaddr_in)));
+  /* A different destination's partition is untouched. */
+  assert(sfu_fanout_mesh_enqueue(&mesh, 0, 2, &fake_pkt, &s2, sizeof(struct sockaddr_in)));
   c.count = 0;
   drained = sfu_fanout_mesh_drain(&mesh, 1, 100, collect, &c);
-  assert(drained == 64);
+  assert(drained == 16);
+  c.count = 0;
+  drained = sfu_fanout_mesh_drain(&mesh, 2, 100, collect, &c);
+  assert(drained == 1);
 
   sfu_fanout_mesh_destroy(&mesh);
   printf("test_fanout_mesh: OK\n");

--- a/tests/test_worker_protocol.c
+++ b/tests/test_worker_protocol.c
@@ -340,14 +340,30 @@ static void test_packet_release_ownership(void) {
   uint8_t garbage[16] = {0xC1, 206, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
   feed_rtcp(&f, garbage, sizeof(garbage));
 
-  /* PLI triggers one throttled keyframe request: the worker's own PLI build
-   * allocs one packet, queues it (retained ref), and drops its own ref. */
+  /* No uplink video SSRC: the keyframe request bail-out path must not
+   * allocate (nor leak) any packet. */
   uint8_t pli[64];
   size_t pli_len = build_pli(pli);
   feed_rtcp(&f, pli, pli_len);
-  feed_rtcp(&f, pli, pli_len); /* throttled: no second keyframe packet */
+  assert(f.session->last_pli_time != 0); /* request throttled/coalesced... */
+  assert(pool_free_count(&f.pp) == POOL_CAPACITY); /* ...but no packet held */
 
+  /* With a video SSRC the PLI is actually built: one packet is allocated,
+   * queued on the send ring (retained ref, never submitted here), and the
+   * builder's own ref is dropped. */
+  f.session->last_pli_time = 0;
+  f.session->uplink_video.ssrc = MEDIA_SSRC;
+  feed_rtcp(&f, pli, pli_len);
   assert(pool_free_count(&f.pp) == POOL_CAPACITY - 1);
+
+  /* Inside the throttle window: coalesced, no second packet. */
+  feed_rtcp(&f, pli, pli_len);
+  assert(pool_free_count(&f.pp) == POOL_CAPACITY - 1);
+
+  /* Outside the window: a new request allocates again. */
+  f.session->last_pli_time -= 2000;
+  feed_rtcp(&f, pli, pli_len);
+  assert(pool_free_count(&f.pp) == POOL_CAPACITY - 2);
   fixture_destroy(&f);
 }
 
@@ -930,6 +946,108 @@ static void test_source_switch_colliding_seq_delayed_nack(void) {
   fixture_destroy(&f);
 }
 
+/* A keyframe request for a publisher owned by another worker must hand a
+ * KEYFRAME_REQUEST job through the mesh without touching the requester's
+ * packet pool (the alloc used to happen before the cross-worker branch and
+ * leak), and it must retain exactly one publisher reference for the job. */
+static void test_kf_request_cross_worker_no_packet_leak(void) {
+  kf_fixture_t f;
+  kf_fixture_init(&f);
+
+  sfu_fanout_mesh_t mesh;
+  assert(sfu_fanout_mesh_init(&mesh, 2, 16, 32) == 0);
+  f.base.w.mesh = &mesh;
+  f.base.w.worker_index = 0;
+  f.publisher->worker_id = 1; /* owned by the other worker */
+
+  uint32_t before = pool_free_count(&f.base.pp);
+  uint32_t ref_before = atomic_load(&f.publisher->refcount);
+
+  sfu_session_request_keyframe(&f.base.w, f.publisher, false);
+
+  assert(pool_free_count(&f.base.pp) == before); /* no packet allocated/leaked */
+  assert(atomic_load(&f.publisher->refcount) == ref_before + 1);
+  assert(f.publisher->last_pli_time == 0); /* timestamp set by owner on execution */
+
+  /* Draining on the publisher's worker executes the PLI build there and
+   * returns the publisher reference. */
+  sfu_worker_t w1;
+  memset(&w1, 0, sizeof(w1));
+  w1.pp = &f.base.pp;
+  w1.sessions = &f.base.sessions;
+  w1.worker_index = 1;
+  w1.mesh = &mesh;
+  int w1_fds[2];
+  assert(pipe(w1_fds) == 0);
+  assert(sfu_ring_init(&w1.send_ring, w1_fds[1], 8, 16, 0, 0, -1, false) == 0);
+
+  unsigned drained = sfu_fanout_mesh_drain(&mesh, 1, 8, sfu_worker_handle_fanout_job, &w1);
+  assert(drained == 1);
+  assert(atomic_load(&f.publisher->refcount) == ref_before);
+  /* Exactly one PLI packet left the pool (queued on w1's send ring, never
+   * submitted, so its retained ref is still out). */
+  assert(pool_free_count(&f.base.pp) == before - 1);
+
+  sfu_ring_destroy(&w1.send_ring);
+  close(w1_fds[0]);
+  close(w1_fds[1]);
+  f.base.w.mesh = NULL;
+  sfu_fanout_mesh_destroy(&mesh);
+  kf_fixture_destroy(&f);
+}
+
+/* When the cross-worker ring is full, the enqueue must fail cleanly: the
+ * publisher reference taken for the job is dropped again (it used to leak,
+ * pinning the session forever). */
+static void test_kf_enqueue_ring_full_drops_ref(void) {
+  kf_fixture_t f;
+  kf_fixture_init(&f);
+
+  sfu_fanout_mesh_t mesh;
+  assert(sfu_fanout_mesh_init(&mesh, 2, 4 /* tiny ring */, 32) == 0);
+  f.base.w.mesh = &mesh;
+  f.base.w.worker_index = 0;
+  f.publisher->worker_id = 1;
+
+  uint32_t ref_before = atomic_load(&f.publisher->refcount);
+
+  /* Fill the 0->1 ring (capacity 4) through the public enqueue path. */
+  for (int i = 0; i < 4; i++) {
+    assert(sfu_fanout_mesh_enqueue_keyframe_request(&mesh, 0, 1, f.publisher));
+  }
+  assert(atomic_load(&f.publisher->refcount) == ref_before + 4);
+
+  /* 5th enqueue: ring full -> must fail and drop the reference it took. */
+  assert(!sfu_fanout_mesh_enqueue_keyframe_request(&mesh, 0, 1, f.publisher));
+  assert(atomic_load(&f.publisher->refcount) == ref_before + 4);
+
+  /* Drain the 4 queued jobs on the publisher worker; each releases its ref. */
+  sfu_worker_t w1;
+  memset(&w1, 0, sizeof(w1));
+  w1.pp = &f.base.pp;
+  w1.sessions = &f.base.sessions;
+  w1.worker_index = 1;
+  w1.mesh = &mesh;
+  int w1_fds[2];
+  assert(pipe(w1_fds) == 0);
+  assert(sfu_ring_init(&w1.send_ring, w1_fds[1], 8, 16, 0, 0, -1, false) == 0);
+
+  unsigned drained = sfu_fanout_mesh_drain(&mesh, 1, 8, sfu_worker_handle_fanout_job, &w1);
+  assert(drained == 4);
+  assert(atomic_load(&f.publisher->refcount) == ref_before);
+
+  /* Execution-side coalescing: 4 queued requests collapse into a single PLI
+   * packet; the other three hit the execution throttle and alloc nothing. */
+  assert(pool_free_count(&f.base.pp) == POOL_CAPACITY - 1);
+
+  sfu_ring_destroy(&w1.send_ring);
+  close(w1_fds[0]);
+  close(w1_fds[1]);
+  f.base.w.mesh = NULL;
+  sfu_fanout_mesh_destroy(&mesh);
+  kf_fixture_destroy(&f);
+}
+
 int main(void) {
   test_compound_nack_rtx_dispatch();
   test_compound_nack_then_pli();
@@ -952,6 +1070,8 @@ int main(void) {
   test_nack_line_rate_throttled_by_rtx_budget();
   test_forward_churn_subscriber_disconnect();
   test_source_switch_colliding_seq_delayed_nack();
+  test_kf_request_cross_worker_no_packet_leak();
+  test_kf_enqueue_ring_full_drops_ref();
   printf("test_worker_protocol: OK\n");
   return 0;
 }


### PR DESCRIPTION
## Tóm tắt

Fix các vấn đề phát hiện khi review fanout cross-core cho media và keyframe request (xem `PIPELINE_REVIEW_REPORT.md`):

### 🔴 Bugs

1. **Packet pool leak trên cross-worker KF request** — `sfu_session_request_keyframe()` alloc packet RTCP *trước* khi check `publisher->worker_id != w->worker_index`; nhánh offload `return` mà không release → mỗi KF request cross-worker leak 1 packet slot. Giờ packet chỉ được alloc trên owner-worker execution path, sau cả nhánh bail-out `media_ssrc == 0` (vốn cũng leak packet vừa alloc).

2. **Publisher refcount leak khi mesh ring đầy** — `sfu_fanout_mesh_enqueue_keyframe_request()` retain ref trước khi push ring nhưng không drop khi push fail → session bị pin vĩnh viễn (không free được, treo `room->peers`). Giờ ref được release trên failure path.

3. **Keyframe request bị nuốt khi media_ssrc không resolve được** — `sfu_worker_request_source_keyframe()` fallback về feedback session nhưng `return` sớm trước khi request. Giờ fallback thực sự gọi `sfu_worker_request_keyframe_throttled()`.

### 🟡 Cải tiến

4. **Job pool partition theo destination worker** — trước đây một pool global khiến mọi worker contention trên cùng lock-free free list cho mỗi packet forward. Giờ mỗi dst worker có partition riêng (`job->pool_dst`/`pool_index` ghi lại home partition để free đúng chỗ), slab nằm chủ yếu trên cache của một core. READY/FORWARD jobs cũng được memset đầy đủ như KEYFRAME jobs.

5. **KF coalescing phía publisher worker** — throttle `last_pli_time` chuyển vào `sfu_session_request_keyframe()` (execution side): N subscriber workers cùng request keyframe cho một publisher giờ collapse thành ≤1 PLI/giây bất kể job được execute ở worker nào. Bỏ throttle trùng lặp ở request side trong worker.c.

### Tests

- `test_fanout_mesh`: cập nhật cho per-dst partitions (64/4 = 16 slots/dst), thêm case partition exhaustion và kiểm tra partition khác không bị ảnh hưởng.
- `test_worker_protocol`: +2 test mới — cross-worker KF không leak packet + refcount round-trip đúng; ring-full drop ref + 4 queued KF jobs coalesce thành đúng 1 PLI packet. `test_packet_release_ownership` viết lại để phân biệt nhánh `ssrc==0` (không alloc) và PLI build thật (expectation cũ vô tình che giấu leak #1).
- **29/29 tests pass**, clean build 0 warning.

### Không đổi

- Ownership model giữ nguyên: SRTP protect cho subscriber/publisher luôn chạy trên owner worker; cross-worker chỉ chuyển plaintext clone + job metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)