### PR TITLE
refactor(pipeline): make sfu_egress_process cover all target workers

### DIFF
--- a/src/pipeline/egress.c
+++ b/src/pipeline/egress.c
@@ -5,6 +5,7 @@
 #include "peer/session.h"
 #include "rtp/rtp_ext.h"
 #include "rtp/rtx.h"
+#include "runtime/fanout.h"
 #include "runtime/timer.h"
 #include "runtime/worker.h"
 #include "transport/srtp/srtp.h"
@@ -12,9 +13,11 @@
 #include "util/metrics.h"
 #include "util/netbytes.h"
 
-void sfu_egress_process(sfu_worker_t *w, sfu_peer_session_t *sub_session, sfu_packet_t *pkt, const struct sockaddr_storage *dst, socklen_t dst_len,
-                        uint32_t video_ssrc, uint8_t video_pt, uint8_t video_rtx_pt, uint32_t video_rtx_ssrc, bool has_video, bool is_audio,
-                        sfu_pacer_class_t video_class) {
+/* Local egress: runs on the worker that owns `sub_session` (its SRTP context,
+ * pacer and TWCC sequence are not thread-safe across workers). */
+static void sfu_egress_process_local(sfu_worker_t *w, sfu_peer_session_t *sub_session, sfu_packet_t *pkt, const struct sockaddr_storage *dst,
+                                     socklen_t dst_len, uint32_t video_ssrc, uint8_t video_pt, uint8_t video_rtx_pt, uint32_t video_rtx_ssrc,
+                                     bool has_video, bool is_audio, sfu_pacer_class_t video_class) {
   int enc_len = (int)pkt->len;
 
   uint8_t incoming_pt = pkt->data[1] & 0x7F;
@@ -59,5 +62,24 @@ void sfu_egress_process(sfu_worker_t *w, sfu_peer_session_t *sub_session, sfu_pa
   if (sfu_ring_queue_send_zc(&w->send_ring, pkt, (const struct sockaddr *)dst, dst_len) != 0) {
     SFU_LOG_WARN("worker %u: [EGRESS DROP] send SQ full", w->worker_index);
     sfu_metric_inc("egress_send_full");
+  }
+}
+
+void sfu_egress_process(sfu_worker_t *w, sfu_peer_session_t *sub_session, sfu_packet_t *pkt, const struct sockaddr_storage *dst, socklen_t dst_len,
+                        uint32_t video_ssrc, uint8_t video_pt, uint8_t video_rtx_pt, uint32_t video_rtx_ssrc, bool has_video, bool is_audio,
+                        sfu_pacer_class_t video_class) {
+  if (sub_session->worker_id == w->worker_index) {
+    sfu_egress_process_local(w, sub_session, pkt, dst, dst_len, video_ssrc, video_pt, video_rtx_pt, video_rtx_ssrc, has_video, is_audio,
+                             video_class);
+    sfu_worker_release_packet(w->pp, &w->release_to_dispatcher, pkt);
+    return;
+  }
+
+  atomic_fetch_add_explicit(&sub_session->refcount, 1, memory_order_relaxed);
+  if (!sfu_fanout_mesh_enqueue_forward(w->mesh, w->worker_index, sub_session->worker_id, pkt, sub_session, dst, dst_len, video_ssrc, video_rtx_ssrc,
+                                       video_pt, video_rtx_pt, has_video, is_audio, (uint8_t)video_class)) {
+    SFU_LOG_WARN("worker %u: fanout queue full", w->worker_index);
+    sfu_session_release(sub_session);
+    sfu_worker_release_packet(w->pp, &w->release_to_dispatcher, pkt);
   }
 }

--- a/src/pipeline/egress.h
+++ b/src/pipeline/egress.h
@@ -11,6 +11,13 @@
 
 typedef struct sfu_worker sfu_worker_t;
 
+/* Per-subscriber egress stage: PT remap -> pacer admission -> RTX cache put
+ * -> TWCC sequence write + send history -> SRTP protect -> UDP send ring.
+ *
+ * Runs for any target worker: if `sub_session` lives on the caller's worker
+ * the packet is processed inline, otherwise it is handed to the owning worker
+ * through the fanout mesh. Takes ownership of `pkt` in all cases (released
+ * locally or by the fanout-job handler). */
 void sfu_egress_process(sfu_worker_t *w, sfu_peer_session_t *sub_session, sfu_packet_t *pkt, const struct sockaddr_storage *dst, socklen_t dst_len,
                         uint32_t video_ssrc, uint8_t video_pt, uint8_t video_rtx_pt, uint32_t video_rtx_ssrc, bool has_video, bool is_audio,
                         sfu_pacer_class_t video_class);

--- a/src/pipeline/router.c
+++ b/src/pipeline/router.c
@@ -7,7 +7,6 @@
 #include "peer/session.h"
 #include "pipeline/egress.h"
 #include "pipeline/keyframe.h"
-#include "runtime/fanout.h"
 #include "runtime/scheduler.h"
 #include "runtime/worker.h"
 #include "util/log.h"
@@ -62,20 +61,8 @@ void sfu_router_forward(sfu_worker_t *w, sfu_peer_session_t *sender_session, sfu
     memcpy(enc->data, pkt->data, pkt->len);
     enc->len = pkt->len;
 
-    if (sub_session->worker_id == w->worker_index) {
-      sfu_egress_process(w, sub_session, enc, &sub_session->cold->addr, sub_session->cold->addr_len, slot->video_ssrc, slot->video_pt, slot->video_rtx_pt,
-                         slot->video_rtx_ssrc, slot->has_video, m->is_audio, video_class);
-      sfu_worker_release_packet(w->pp, &w->release_to_dispatcher, enc);
-    } else {
-      atomic_fetch_add_explicit(&sub_session->refcount, 1, memory_order_relaxed);
-      if (!sfu_fanout_mesh_enqueue_forward(w->mesh, w->worker_index, sub_session->worker_id, enc, sub_session, &sub_session->cold->addr,
-                                           sub_session->cold->addr_len, slot->video_ssrc, slot->video_rtx_ssrc, slot->video_pt, slot->video_rtx_pt,
-                                           slot->has_video, m->is_audio, (uint8_t)video_class)) {
-        SFU_LOG_WARN("worker %u: fanout queue full", w->worker_index);
-        sfu_session_release(sub_session);
-        sfu_worker_release_packet(w->pp, &w->release_to_dispatcher, enc);
-      }
-    }
+    sfu_egress_process(w, sub_session, enc, &sub_session->cold->addr, sub_session->cold->addr_len, slot->video_ssrc, slot->video_pt, slot->video_rtx_pt,
+                       slot->video_rtx_ssrc, slot->has_video, m->is_audio, video_class);
   }
 
   sfu_subscriptions_snapshot_release(snap);

--- a/src/runtime/fanout_job.c
+++ b/src/runtime/fanout_job.c
@@ -17,9 +17,14 @@ void sfu_worker_handle_fanout_job(void *user_data, sfu_fanout_job_t *job) {
     sfu_fanout_mesh_free_job(w->mesh, job);
     return;
   } else if (job->kind == SFU_FANOUT_JOB_FORWARD && job->subscriber) {
+    /* The job always lands on the subscriber's owning worker (see
+     * sfu_fanout_mesh_enqueue_forward), so this runs the local path.
+     * sfu_egress_process consumes job->pkt. */
     sfu_egress_process(w, job->subscriber, job->pkt, &job->dst, job->dst_len, job->video_ssrc, job->video_pt, job->video_rtx_pt, job->video_rtx_ssrc,
                        job->has_video, job->is_audio, (sfu_pacer_class_t)job->pacer_class);
     sfu_session_release(job->subscriber);
+    sfu_fanout_mesh_free_job(w->mesh, job);
+    return;
   } else {
     if (sfu_ring_queue_send_zc(&w->send_ring, job->pkt, (const struct sockaddr *)&job->dst, job->dst_len) != 0) {
       SFU_LOG_WARN("worker %u: [EGRESS DROP] remote-fanout send SQ full, dropping packet", w->worker_index);


### PR DESCRIPTION
## Vấn đề

`sfu_egress_process` trước đây chỉ xử lý nhánh same-core. Nhánh cross-core (`sfu_fanout_mesh_enqueue_forward`) nằm trong `sfu_router_forward` qua `if (sub_session->worker_id == w->worker_index) {} else {}`, khiến egress stage không bao trọn toàn bộ core — đúng ra egress phải bao hàm cả `sfu_ring_queue_send_zc` lẫn `sfu_fanout_mesh_enqueue_forward`.

## Thay đổi

- **`src/pipeline/egress.c`**: tách phần xử lý local thành `sfu_egress_process_local` (static). `sfu_egress_process` giờ tự phân nhánh theo `worker_id`:
  - **same-core** → xử lý inline (PT remap → pacer → RTX cache → TWCC → SRTP protect → `sfu_ring_queue_send_zc`) rồi release packet.
  - **cross-core** → tăng refcount, `sfu_fanout_mesh_enqueue_forward` sang owning worker (job handler chạy local path ở worker đích); enqueue fail thì release refcount + packet.
  - Hàm giờ **take ownership** của `pkt` trong mọi trường hợp.
- **`src/pipeline/router.c`**: `sfu_router_forward` chỉ còn một lờ�i gọi `sfu_egress_process` duy nhất, bỏ hẳn if/else theo `worker_id`; xóa include `runtime/fanout.h` thừa.
- **`src/pipeline/egress.h`**: cập nhật comment mô tả semantics mới.
- **`src/runtime/fanout_job.c`**: nhánh `SFU_FANOUT_JOB_FORWARD` return sớm sau khi xử lý để tránh double-release packet (vì `sfu_egress_process` giờ tự release).

## Kiểm chứng

- Build thành công (`mezon-sfu`).
- 29/29 tests pass (bao gồm `fanout_mesh`, `worker_protocol`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)