### PR TITLE
feat(room): support self-service audience role changes

### DIFF
--- a/include/sfu/datadef.h
+++ b/include/sfu/datadef.h
@@ -173,7 +173,10 @@ typedef struct sfu_peer_session {
   sfu_pacer_t pacer;
   sfu_rtx_cache_t *rtx_cache;
   sfu_peer_session_cold_t *cold;
+  /* Remote media sources used by SDP construction. */
   _Atomic(sfu_receiver_snapshot_t *) receivers;
+  /* Local fanout targets used exclusively by the RTP router. */
+  _Atomic(sfu_receiver_snapshot_t *) fanout_targets;
   sfu_srtp_ctx_t srtp;
   sfu_transceiver_t uplink_audio;
   sfu_transceiver_t uplink_video;
@@ -195,7 +198,7 @@ typedef struct sfu_peer_session {
   _Atomic bool accepts_work;
   uint8_t state;
   uint8_t fir_seq;
-  bool is_audience;
+  _Atomic bool is_audience;
   bool active;
   bool negotiation_needed;
 } sfu_peer_session_t;

--- a/src/peer/session.c
+++ b/src/peer/session.c
@@ -79,7 +79,7 @@ static uint32_t addr_probe(sfu_hash_slot_t *table, uint32_t cap, uint32_t hash, 
 }
 
 sfu_receiver_snapshot_t *sfu_session_subscriptions_acquire(const sfu_peer_session_t *s) {
-  if (!s || s->is_audience) {
+  if (!s) {
     return NULL;
   }
   sfu_receiver_snapshot_t *snap = atomic_load_explicit(&s->receivers, memory_order_acquire);
@@ -116,6 +116,30 @@ void sfu_session_publish_receivers(sfu_peer_session_t *owner, sfu_receiver_snaps
   sfu_subscriptions_snapshot_release(old);
 }
 
+sfu_receiver_snapshot_t *sfu_session_fanout_targets_acquire(const sfu_peer_session_t *s) {
+  if (!s) {
+    return NULL;
+  }
+  sfu_receiver_snapshot_t *snap = atomic_load_explicit(&s->fanout_targets, memory_order_acquire);
+  while (snap) {
+    uint32_t rc = atomic_load_explicit(&snap->refcount, memory_order_relaxed);
+    if (rc == 0) {
+      snap = atomic_load_explicit(&s->fanout_targets, memory_order_acquire);
+      continue;
+    }
+    if (atomic_compare_exchange_weak_explicit(&snap->refcount, &rc, rc + 1, memory_order_acquire, memory_order_relaxed)) {
+      return snap;
+    }
+  }
+  return NULL;
+}
+
+void sfu_session_publish_fanout_targets(sfu_peer_session_t *owner, sfu_receiver_snapshot_t *new_snap) {
+  sfu_receiver_snapshot_t *old = atomic_load_explicit(&owner->fanout_targets, memory_order_acquire);
+  atomic_store_explicit(&owner->fanout_targets, new_snap, memory_order_release);
+  sfu_subscriptions_snapshot_release(old);
+}
+
 static void sfu_session_free_resources(sfu_peer_session_t *s) {
   if (!s) {
     return;
@@ -133,6 +157,11 @@ static void sfu_session_free_resources(sfu_peer_session_t *s) {
   sfu_receiver_snapshot_t *snap = atomic_load_explicit(&s->receivers, memory_order_acquire);
   if (snap) {
     atomic_store_explicit(&s->receivers, NULL, memory_order_release);
+    sfu_subscriptions_snapshot_release(snap);
+  }
+  snap = atomic_load_explicit(&s->fanout_targets, memory_order_acquire);
+  if (snap) {
+    atomic_store_explicit(&s->fanout_targets, NULL, memory_order_release);
     sfu_subscriptions_snapshot_release(snap);
   }
 
@@ -320,6 +349,8 @@ sfu_peer_session_t *sfu_session_table_get_or_create(sfu_session_table_t *t, cons
   s->screen.owner = s;
 
   atomic_store_explicit(&s->receivers, NULL, memory_order_relaxed);
+  atomic_store_explicit(&s->fanout_targets, NULL, memory_order_relaxed);
+  atomic_store_explicit(&s->is_audience, false, memory_order_relaxed);
 
   s->next_remote_mid = 2;
 

--- a/src/peer/session.h
+++ b/src/peer/session.h
@@ -21,9 +21,14 @@ void sfu_session_table_remove(sfu_session_table_t *t, sfu_peer_session_t *s);
 bool sfu_session_table_rebind_addr(sfu_session_table_t *t, sfu_peer_session_t *s, const struct sockaddr_storage *addr, socklen_t addr_len);
 bool sfu_session_table_index_ufrag(sfu_session_table_t *t, sfu_peer_session_t *session);
 void sfu_session_request_keyframe(sfu_worker_t *w, sfu_peer_session_t *publisher, bool use_fir);
+/* Remote sources (subscriber-owned) used by SDP construction. */
 sfu_receiver_snapshot_t *sfu_session_subscriptions_acquire(const sfu_peer_session_t *s);
 void sfu_subscriptions_snapshot_release(sfu_receiver_snapshot_t *snap);
 void sfu_session_publish_receivers(sfu_peer_session_t *owner, sfu_receiver_snapshot_t *new_snap);
+
+/* Fanout targets (publisher-owned) used by the RTP router. */
+sfu_receiver_snapshot_t *sfu_session_fanout_targets_acquire(const sfu_peer_session_t *s);
+void sfu_session_publish_fanout_targets(sfu_peer_session_t *owner, sfu_receiver_snapshot_t *new_snap);
 
 static inline bool sfu_session_accepts_work(const sfu_peer_session_t *s) { return atomic_load_explicit(&s->accepts_work, memory_order_acquire); }
 

--- a/src/pipeline/dispatch.c
+++ b/src/pipeline/dispatch.c
@@ -178,7 +178,7 @@ static void handle_stun(sfu_worker_t *w, sfu_packet_t *pkt) {
             session->uplink_video.active = (pending_video_ssrc != 0);
             session->uplink_video.payload_type = pending_video_pt;
             session->uplink_video.rtx_payload_type = pending_rtx_pt;
-            session->is_audience = pending_is_audience;
+            atomic_store_explicit(&session->is_audience, pending_is_audience, memory_order_release);
             for (int pi = 0; pi < 128; pi++) {
               session->pt_map[pi] = (uint8_t)pi;
             }

--- a/src/pipeline/ingress.c
+++ b/src/pipeline/ingress.c
@@ -316,6 +316,13 @@ void sfu_ingress_process(sfu_worker_t *w, sfu_packet_t *pkt) {
   }
 
   bool is_rtcp = sfu_rtp_is_rtcp(pkt->data, pkt->len);
+  if (!is_rtcp && atomic_load_explicit(&sender_session->is_audience, memory_order_acquire)) {
+    sfu_metric_inc("audience_rtp_drop");
+    sfu_worker_release_packet(w->pp, &w->release_to_dispatcher, pkt);
+    sfu_session_release(sender_session);
+    return;
+  }
+
   int plain_len = (int)pkt->len;
   bool unprotected =
       is_rtcp ? sfu_srtp_unprotect_rtcp(&sender_session->srtp, pkt->data, &plain_len) : sfu_srtp_unprotect_rtp(&sender_session->srtp, pkt->data, &plain_len);

--- a/src/pipeline/router.c
+++ b/src/pipeline/router.c
@@ -14,7 +14,7 @@
 void sfu_router_forward(sfu_worker_t *w, sfu_peer_session_t *sender_session, sfu_ingress_media_t *m) {
   sfu_packet_t *pkt = m->pkt;
 
-  sfu_receiver_snapshot_t *snap = sfu_session_subscriptions_acquire(sender_session);
+  sfu_receiver_snapshot_t *snap = sfu_session_fanout_targets_acquire(sender_session);
   uint32_t receiver_count = snap ? snap->count : 0;
 
   for (uint32_t i = 0; i < receiver_count; i++) {

--- a/src/protocol/signaling/sdp.c
+++ b/src/protocol/signaling/sdp.c
@@ -180,7 +180,8 @@ static int append_remote_video_ssrcs(char *out, size_t out_cap, size_t *offset, 
 }
 
 
-int sfu_sdp_build_initial_offer(const char *host, uint16_t port, const char *ufrag, const char *pwd, const char *fingerprint, char *out, size_t out_cap) {
+int sfu_sdp_build_initial_offer(const char *host, uint16_t port, const char *ufrag, const char *pwd, const char *fingerprint, bool is_audience, char *out,
+                                size_t out_cap) {
   size_t off = 0;
   char buf[512];
   int n;
@@ -220,7 +221,7 @@ int sfu_sdp_build_initial_offer(const char *host, uint16_t port, const char *ufr
     return -1;
   }
 
-  if (append_line(out, out_cap, &off, "a=recvonly") != 0) {
+  if (append_line(out, out_cap, &off, is_audience ? "a=inactive" : "a=recvonly") != 0) {
     return -1;
   }
 
@@ -248,7 +249,7 @@ int sfu_sdp_build_initial_offer(const char *host, uint16_t port, const char *ufr
     return -1;
   }
 
-  if (append_line(out, out_cap, &off, "a=recvonly") != 0) {
+  if (append_line(out, out_cap, &off, is_audience ? "a=inactive" : "a=recvonly") != 0) {
     return -1;
   }
 
@@ -366,20 +367,21 @@ int sfu_sdp_build_answer(const sfu_peer_session_t *session, const char *offer, s
       continue;
     }
 
+    bool audience_local_media = atomic_load_explicit(&session->is_audience, memory_order_acquire) && (current_media == 1 || current_media == 2);
     if (starts_with(line, len, "a=sendonly")) {
-      if (append_line(out, out_cap, &off, "a=recvonly") != 0) {
+      if (append_line(out, out_cap, &off, audience_local_media ? "a=inactive" : "a=recvonly") != 0) {
         goto fail;
       }
       continue;
     }
     if (starts_with(line, len, "a=recvonly")) {
-      if (append_line(out, out_cap, &off, "a=sendonly") != 0) {
+      if (append_line(out, out_cap, &off, audience_local_media ? "a=inactive" : "a=sendonly") != 0) {
         goto fail;
       }
       continue;
     }
     if (starts_with(line, len, "a=sendrecv")) {
-      if (append_line(out, out_cap, &off, "a=sendrecv") != 0) {
+      if (append_line(out, out_cap, &off, audience_local_media ? "a=inactive" : "a=sendrecv") != 0) {
         goto fail;
       }
       continue;
@@ -602,7 +604,7 @@ int sfu_sdp_build_offer(const sfu_peer_session_t *session, const char *host, uin
   if (append_media_transport_headers(out, out_cap, &off, host, port, ufrag, pwd, fingerprint) != 0) {
     goto fail;
   }
-  if (append_line(out, out_cap, &off, "a=recvonly") != 0) {
+  if (append_line(out, out_cap, &off, atomic_load_explicit(&session->is_audience, memory_order_acquire) ? "a=inactive" : "a=recvonly") != 0) {
     goto fail;
   }
   if (append_line(out, out_cap, &off, "a=mid:0") != 0) {
@@ -626,7 +628,7 @@ int sfu_sdp_build_offer(const sfu_peer_session_t *session, const char *host, uin
   if (append_media_transport_headers(out, out_cap, &off, host, port, ufrag, pwd, fingerprint) != 0) {
     goto fail;
   }
-  if (append_line(out, out_cap, &off, "a=recvonly") != 0) {
+  if (append_line(out, out_cap, &off, atomic_load_explicit(&session->is_audience, memory_order_acquire) ? "a=inactive" : "a=recvonly") != 0) {
     goto fail;
   }
   if (append_line(out, out_cap, &off, "a=mid:1") != 0) {

--- a/src/protocol/signaling/sdp.h
+++ b/src/protocol/signaling/sdp.h
@@ -39,6 +39,7 @@ int sfu_sdp_build_answer(const sfu_peer_session_t *session, const char *offer, s
 int sfu_sdp_build_offer(const sfu_peer_session_t *session, const char *host, uint16_t port, const char *ufrag, const char *pwd, const char *fingerprint,
                         char *out, size_t out_cap);
 
-int sfu_sdp_build_initial_offer(const char *host, uint16_t port, const char *ufrag, const char *pwd, const char *fingerprint, char *out, size_t out_cap);
+int sfu_sdp_build_initial_offer(const char *host, uint16_t port, const char *ufrag, const char *pwd, const char *fingerprint, bool is_audience, char *out,
+                                size_t out_cap);
 
 #endif /* SFU_PROTOCOL_SDP_H */

--- a/src/protocol/signaling/signaling.c
+++ b/src/protocol/signaling/signaling.c
@@ -19,6 +19,7 @@
 #include "protocol/signaling/json_lite.h"
 #include "protocol/signaling/sdp.h"
 #include "protocol/websocket/ws.h"
+#include "room/room_media_graph.h"
 #include "room/room_registry.h"
 #include "runtime/routing_context.h"
 #include "runtime/scheduler.h"
@@ -246,11 +247,11 @@ static void extract_sdp_video_pts(const char *sdp, size_t sdp_len, uint8_t *vide
   }
 }
 
-static bool build_and_send_initial_offer(int fd, sfu_signaling_server_t *s) {
+static bool build_and_send_initial_offer(int fd, bool is_audience, sfu_signaling_server_t *s) {
   char offer[SFU_SIGNALING_SDP_CAP];
 
-  int offer_len =
-      sfu_sdp_build_initial_offer(s->media_host, s->media_port, s->ice_creds->ufrag, s->ice_creds->pwd, s->dtls_ctx->fingerprint, offer, sizeof(offer));
+  int offer_len = sfu_sdp_build_initial_offer(s->media_host, s->media_port, s->ice_creds->ufrag, s->ice_creds->pwd, s->dtls_ctx->fingerprint,
+                                              is_audience, offer, sizeof(offer));
 
   if (offer_len < 0) {
     SFU_LOG_WARN("signaling: failed to build initial SDP offer (fd=%d)", fd);
@@ -609,7 +610,7 @@ static void on_client_readable(uv_poll_t *handle, int status, int events) {
                 snprintf(response, sizeof(response), "{\"type\":\"joined\",\"room\":\"%" PRIu64 "\"}", room_id);
                 sfu_ws_send_text(c->fd, response, strlen(response));
 
-                if (!build_and_send_initial_offer(c->fd, s)) {
+                if (!build_and_send_initial_offer(c->fd, c->is_audience, s)) {
                   SFU_LOG_WARN("signaling: failed to send initial offer (fd=%d)", c->fd);
                 }
               }
@@ -634,12 +635,20 @@ static void on_client_readable(uv_poll_t *handle, int status, int events) {
                 if (session) {
                   session->user_id = c->user_id;
                   session->peer_id = generate_unique_id();
-                  session->is_audience = c->is_audience;
+                  bool role_changed = false;
+                  if (session->room) {
+                    role_changed = room_update_peer_role((sfu_room_t *)session->room, session, c->is_audience);
+                  } else {
+                    atomic_store_explicit(&session->is_audience, c->is_audience, memory_order_release);
+                  }
                   handle_answer(session, sdp, sdp_len);
-                  sfu_session_release(session);
+                  if (role_changed) {
+                    sfu_signaling_trigger_renegotiation((sfu_room_t *)session->room);
+                  }
                   if (session->schedulers) {
                     sfu_layer_selector_switch_source(session, session->peer_id);
                   }
+                  sfu_session_release(session);
                 } else {
                   uint32_t audio_ssrc = 0, video_ssrc = 0, rtx_ssrc = 0;
                   uint8_t video_pt = 0, rtx_pt = 0;
@@ -650,6 +659,37 @@ static void on_client_readable(uv_poll_t *handle, int status, int events) {
                                                        generate_unique_id(), c->is_audience);
                   SFU_LOG_WARN("signaling: answer for ufrag=%s arrived before session was created; stashed parsed SSRCs for apply on bind", c->client_ufrag);
                 }
+              }
+            }
+          } else if (strcmp(type, "raise_hand") == 0 || strcmp(type, "role_change") == 0) {
+            char role_str[16] = {0};
+            bool raise_hand = strcmp(type, "raise_hand") == 0;
+            if (raise_hand) {
+              snprintf(role_str, sizeof(role_str), "speaker");
+            }
+            if (!c->joined_room || c->client_ufrag[0] == '\0' ||
+                (!raise_hand && sfu_json_extract_string(buf, (size_t)n, "role", role_str, sizeof(role_str)) < 0) ||
+                (strcmp(role_str, "speaker") != 0 && strcmp(role_str, "audience") != 0)) {
+              static const char invalid_role_change[] = "{\"type\":\"error\",\"message\":\"invalid_role_change\"}";
+              sfu_ws_send_text(c->fd, invalid_role_change, sizeof(invalid_role_change) - 1);
+            } else {
+              bool is_audience = strcmp(role_str, "audience") == 0;
+              sfu_peer_session_t *session = sfu_session_table_find_by_ufrag(s->sessions, c->client_ufrag);
+              if (!session || session->room != c->joined_room || !room_update_peer_role(c->joined_room, session, is_audience)) {
+                static const char role_change_rejected[] = "{\"type\":\"error\",\"message\":\"role_change_rejected\"}";
+                sfu_ws_send_text(c->fd, role_change_rejected, sizeof(role_change_rejected) - 1);
+              } else {
+                c->is_audience = is_audience;
+                char response[128];
+                int response_len = snprintf(response, sizeof(response), "{\"type\":\"role_changed\",\"user_id\":\"%" PRIu64 "\",\"role\":\"%s\"}",
+                                            c->user_id, role_str);
+                if (response_len > 0 && (size_t)response_len < sizeof(response)) {
+                  sfu_ws_send_text(c->fd, response, (size_t)response_len);
+                }
+                sfu_signaling_trigger_renegotiation(c->joined_room);
+              }
+              if (session) {
+                sfu_session_release(session);
               }
             }
           } else {

--- a/src/room/room_media_graph.c
+++ b/src/room/room_media_graph.c
@@ -47,8 +47,10 @@ static sfu_receiver_snapshot_t *snapshot_alloc(uint32_t capacity) {
   return snap;
 }
 
-static sfu_receiver_snapshot_t *snapshot_build_with(sfu_peer_session_t *owner, sfu_peer_session_t *dst) {
-  sfu_receiver_snapshot_t *old = sfu_session_subscriptions_acquire(owner);
+/* Source snapshots are subscriber-owned and drive SDP remote-track sections;
+ * fanout snapshots are publisher-owned and drive RTP forwarding. */
+static sfu_receiver_snapshot_t *snapshot_build_with(sfu_peer_session_t *owner, sfu_peer_session_t *dst, bool fanout) {
+  sfu_receiver_snapshot_t *old = fanout ? sfu_session_fanout_targets_acquire(owner) : sfu_session_subscriptions_acquire(owner);
   if (snapshot_find(old, dst) != UINT32_MAX) {
     sfu_subscriptions_snapshot_release(old);
     return NULL;
@@ -69,8 +71,10 @@ static sfu_receiver_snapshot_t *snapshot_build_with(sfu_peer_session_t *owner, s
 
   sfu_receiver_entry_t *e = &snap->entries[old_count];
   memset(e, 0, sizeof(*e));
-  e->mid_audio = owner->next_remote_mid++;
-  e->mid_video = owner->next_remote_mid++;
+  if (!fanout) {
+    e->mid_audio = owner->next_remote_mid++;
+    e->mid_video = owner->next_remote_mid++;
+  }
   snapshot_fill_entry(e, dst);
   e->has_audio = true;
   e->has_video = true;
@@ -80,8 +84,8 @@ static sfu_receiver_snapshot_t *snapshot_build_with(sfu_peer_session_t *owner, s
   return snap;
 }
 
-static sfu_receiver_snapshot_t *snapshot_build_without(sfu_peer_session_t *owner, const sfu_peer_session_t *dst) {
-  sfu_receiver_snapshot_t *old = sfu_session_subscriptions_acquire(owner);
+static sfu_receiver_snapshot_t *snapshot_build_without(sfu_peer_session_t *owner, const sfu_peer_session_t *dst, bool fanout) {
+  sfu_receiver_snapshot_t *old = fanout ? sfu_session_fanout_targets_acquire(owner) : sfu_session_subscriptions_acquire(owner);
   uint32_t pos = snapshot_find(old, dst);
   if (pos == UINT32_MAX) {
     sfu_subscriptions_snapshot_release(old);
@@ -115,6 +119,10 @@ static void snapshot_replace(sfu_peer_session_t *owner, sfu_receiver_snapshot_t 
   owner->negotiation_needed = true;
 }
 
+static void fanout_snapshot_replace(sfu_peer_session_t *owner, sfu_receiver_snapshot_t *new_snap) {
+  sfu_session_publish_fanout_targets(owner, new_snap);
+}
+
 void room_add_peer(sfu_room_t *room, sfu_peer_session_t *peer) {
   pthread_mutex_lock(&room->lock);
 
@@ -141,22 +149,92 @@ void room_add_peer(sfu_room_t *room, sfu_peer_session_t *peer) {
       continue;
     }
 
-    sfu_receiver_snapshot_t *snap = snapshot_build_with(other, peer);
-    if (snap) {
-      snapshot_replace(other, snap);
-    } else {
-      SFU_LOG_WARN("room %" PRIu64 ": failed to build receiver snapshot for peer subscribing to %s", room->room_id, peer->cold ? peer->cold->ufrag : "?");
+    bool peer_is_audience = atomic_load_explicit(&peer->is_audience, memory_order_acquire);
+    bool other_is_audience = atomic_load_explicit(&other->is_audience, memory_order_acquire);
+
+    /* Every participant needs every speaker as an SDP remote source. */
+    if (!peer_is_audience) {
+      sfu_receiver_snapshot_t *snap = snapshot_build_with(other, peer, false);
+      if (snap) {
+        snapshot_replace(other, snap);
+      }
+    }
+    if (!other_is_audience) {
+      sfu_receiver_snapshot_t *snap = snapshot_build_with(peer, other, false);
+      if (snap) {
+        snapshot_replace(peer, snap);
+      }
     }
 
-    snap = snapshot_build_with(peer, other);
-    if (snap) {
-      snapshot_replace(peer, snap);
-    } else {
-      SFU_LOG_WARN("room %" PRIu64 ": failed to build receiver snapshot for %s subscribing to peer", room->room_id, peer->cold ? peer->cold->ufrag : "?");
+    /* A speaker forwards to every participant. Audiences have no fanout view. */
+    if (!peer_is_audience) {
+      sfu_receiver_snapshot_t *snap = snapshot_build_with(peer, other, true);
+      if (snap) {
+        fanout_snapshot_replace(peer, snap);
+      }
+    }
+    if (!other_is_audience) {
+      sfu_receiver_snapshot_t *snap = snapshot_build_with(other, peer, true);
+      if (snap) {
+        fanout_snapshot_replace(other, snap);
+      }
     }
   }
 
   pthread_mutex_unlock(&room->lock);
+}
+
+bool room_update_peer_role(sfu_room_t *room, sfu_peer_session_t *peer, bool is_audience) {
+  if (!room || !peer) {
+    return false;
+  }
+
+  pthread_mutex_lock(&room->lock);
+  if (peer->room != room || atomic_load_explicit(&peer->is_audience, memory_order_acquire) == is_audience) {
+    pthread_mutex_unlock(&room->lock);
+    return false;
+  }
+
+  atomic_store_explicit(&peer->is_audience, is_audience, memory_order_release);
+  for (uint32_t i = 0; i < room->peer_count; i++) {
+    sfu_peer_session_t *other = room->peers[i];
+    if (!other || other == peer || !sfu_session_accepts_work(other)) {
+      continue;
+    }
+
+    if (is_audience) {
+      /* Demotion removes this speaker from every subscriber's SDP source list.
+       * Existing speakers keep the peer as a fanout target so it still listens. */
+      sfu_receiver_snapshot_t *snap = snapshot_build_without(other, peer, false);
+      if (snap) {
+        snapshot_replace(other, snap);
+      }
+    } else {
+      /* Promotion exposes the peer as a source and gives it all room members
+       * as fanout targets. The source view already contains existing speakers
+       * from its audience role, so only other peers need the new source. */
+      sfu_receiver_snapshot_t *snap = snapshot_build_with(other, peer, false);
+      if (snap) {
+        snapshot_replace(other, snap);
+      }
+      snap = snapshot_build_with(peer, other, true);
+      if (snap) {
+        fanout_snapshot_replace(peer, snap);
+      }
+    }
+  }
+
+  if (is_audience) {
+    sfu_receiver_snapshot_t *empty = snapshot_alloc(0);
+    if (empty) {
+      empty->generation = 0;
+    }
+    sfu_session_publish_fanout_targets(peer, empty);
+  }
+
+  peer->negotiation_needed = true;
+  pthread_mutex_unlock(&room->lock);
+  return true;
 }
 
 void room_remove_peer(sfu_room_t *room, sfu_peer_session_t *peer) {
@@ -190,9 +268,13 @@ void room_remove_peer(sfu_room_t *room, sfu_peer_session_t *peer) {
     if (!other) {
       continue;
     }
-    sfu_receiver_snapshot_t *snap = snapshot_build_without(other, peer);
+    sfu_receiver_snapshot_t *snap = snapshot_build_without(other, peer, false);
     if (snap) {
       snapshot_replace(other, snap);
+    }
+    snap = snapshot_build_without(other, peer, true);
+    if (snap) {
+      fanout_snapshot_replace(other, snap);
     }
   }
 
@@ -204,6 +286,11 @@ void room_remove_peer(sfu_room_t *room, sfu_peer_session_t *peer) {
     SFU_LOG_ERROR("room %" PRIu64 ": failed to allocate empty snapshot; clearing receivers in place", room->room_id);
     sfu_session_publish_receivers(peer, NULL);
   }
+  empty = snapshot_alloc(0);
+  if (empty) {
+    empty->generation = 0;
+  }
+  sfu_session_publish_fanout_targets(peer, empty);
 
   peer->room = NULL;
   peer->negotiation_needed = false;

--- a/src/room/room_media_graph.h
+++ b/src/room/room_media_graph.h
@@ -7,4 +7,8 @@
 void room_add_peer(sfu_room_t *room, sfu_peer_session_t *peer);
 void room_remove_peer(sfu_room_t *room, sfu_peer_session_t *peer);
 
+/* Change a joined peer's self-service role. Returns false when the peer is not
+ * a current room member or the requested role is already active. */
+bool room_update_peer_role(sfu_room_t *room, sfu_peer_session_t *peer, bool is_audience);
+
 #endif  // SFU_ROOM_MEDIA_GRAPH_H

--- a/tests/test_room.c
+++ b/tests/test_room.c
@@ -37,6 +37,28 @@ static uint32_t receiver_count(sfu_peer_session_t *peer) {
   return n;
 }
 
+static uint32_t fanout_target_count(sfu_peer_session_t *peer) {
+  sfu_receiver_snapshot_t *snap = sfu_session_fanout_targets_acquire(peer);
+  uint32_t n = snap ? snap->count : 0;
+  sfu_subscriptions_snapshot_release(snap);
+  return n;
+}
+
+static bool fanout_targets(sfu_peer_session_t *peer, sfu_peer_session_t *dest) {
+  sfu_receiver_snapshot_t *snap = sfu_session_fanout_targets_acquire(peer);
+  bool found = false;
+  if (snap) {
+    for (uint32_t i = 0; i < snap->count; i++) {
+      if (snap->entries[i].subscriber == dest) {
+        found = true;
+        break;
+      }
+    }
+  }
+  sfu_subscriptions_snapshot_release(snap);
+  return found;
+}
+
 static bool subscribes_to(sfu_peer_session_t *peer, sfu_peer_session_t *dest) {
   sfu_receiver_snapshot_t *snap = sfu_session_subscriptions_acquire(peer);
   bool found = false;
@@ -131,6 +153,46 @@ static void test_add_remove(void) {
 }
 
 /* Old snapshot stays valid for a holder across a concurrent replacement. */
+static void test_audience_role_asymmetry_and_transition(void) {
+  sfu_room_t room;
+  assert(sfu_room_init(&room, 4) == 0);
+
+  sfu_peer_session_t *speaker = mock_session("speaker");
+  sfu_peer_session_t *audience = mock_session("audience");
+  atomic_store(&audience->is_audience, true);
+
+  room_add_peer(&room, speaker);
+  room_add_peer(&room, audience);
+
+  /* Audience receives the speaker SDP source but never owns an RTP fanout
+   * snapshot. The speaker forwards to the audience. */
+  assert(receiver_count(audience) == 1);
+  assert(subscribes_to(audience, speaker));
+  assert(receiver_count(speaker) == 0);
+  assert(fanout_target_count(speaker) == 1);
+  assert(fanout_targets(speaker, audience));
+  assert(fanout_target_count(audience) == 0);
+
+  assert(room_update_peer_role(&room, audience, false));
+  assert(!atomic_load(&audience->is_audience));
+  assert(receiver_count(speaker) == 1);
+  assert(subscribes_to(speaker, audience));
+  assert(fanout_target_count(audience) == 1);
+  assert(fanout_targets(audience, speaker));
+
+  assert(room_update_peer_role(&room, audience, true));
+  assert(atomic_load(&audience->is_audience));
+  assert(receiver_count(speaker) == 0);
+  assert(fanout_target_count(audience) == 0);
+  assert(fanout_targets(speaker, audience));
+
+  room_remove_peer(&room, audience);
+  room_remove_peer(&room, speaker);
+  sfu_session_release(audience);
+  sfu_session_release(speaker);
+  sfu_room_destroy(&room);
+}
+
 static void test_snapshot_hold_across_replace(void) {
   sfu_room_t room;
   assert(sfu_room_init(&room, 2) == 0);
@@ -339,6 +401,7 @@ static void test_multi_publisher_concurrent_churn(void) {
 
 int main(void) {
   test_add_remove();
+  test_audience_role_asymmetry_and_transition();
   test_snapshot_hold_across_replace();
   test_concurrent_snapshot_read_write();
   test_multi_publisher_concurrent_churn();

--- a/tests/test_sdp.c
+++ b/tests/test_sdp.c
@@ -163,6 +163,43 @@ static void cleanup_mock_session(sfu_peer_session_t *session, sfu_peer_session_t
 
 /* CC-11: the answer-side extmap negotiation extractor accepts the URI forms
  * browsers emit and rejects garbage. */
+static void test_initial_offer_role_directions(void) {
+  char offer[4096];
+  int len = sfu_sdp_build_initial_offer("127.0.0.1", 17030, "sfuUfrag", "sfuPasswordValueGoesHereXXXX", "AA:BB", false, offer, sizeof(offer));
+  assert(len > 0);
+  offer[len] = '\0';
+  assert(count_occurrences(offer, "a=recvonly") == 2);
+  assert(!contains(offer, "a=inactive"));
+
+  len = sfu_sdp_build_initial_offer("127.0.0.1", 17030, "sfuUfrag", "sfuPasswordValueGoesHereXXXX", "AA:BB", true, offer, sizeof(offer));
+  assert(len > 0);
+  offer[len] = '\0';
+  assert(count_occurrences(offer, "a=inactive") == 2);
+  assert(!contains(offer, "a=recvonly"));
+}
+
+static void test_renegotiation_offer_role_directions(void) {
+  sfu_peer_session_t session;
+  memset(&session, 0, sizeof(session));
+  session.cold = calloc(1, sizeof(*session.cold));
+  assert(session.cold != NULL);
+  session.next_remote_mid = 2;
+
+  char offer[4096];
+  int len = sfu_sdp_build_offer(&session, "127.0.0.1", 17030, "sfuUfrag", "sfuPasswordValueGoesHereXXXX", "AA:BB", offer, sizeof(offer));
+  assert(len > 0);
+  offer[len] = '\0';
+  assert(count_occurrences(offer, "a=recvonly") == 2);
+
+  atomic_store(&session.is_audience, true);
+  len = sfu_sdp_build_offer(&session, "127.0.0.1", 17030, "sfuUfrag", "sfuPasswordValueGoesHereXXXX", "AA:BB", offer, sizeof(offer));
+  assert(len > 0);
+  offer[len] = '\0';
+  assert(count_occurrences(offer, "a=inactive") == 2);
+
+  free(session.cold);
+}
+
 static void test_twcc_extmap_extraction(void) {
   extern uint8_t sfu_test_extract_twcc_extmap_id(const char *sdp, size_t sdp_len);
 
@@ -464,6 +501,8 @@ int main(void) {
   cleanup_mock_session(&session1, r1);
   cleanup_mock_session(&session2, r2);
 
+  test_initial_offer_role_directions();
+  test_renegotiation_offer_role_directions();
   test_twcc_extmap_extraction();
   test_concurrent_build_vs_teardown();
 

--- a/tests/test_session_table.c
+++ b/tests/test_session_table.c
@@ -291,16 +291,16 @@ static void test_audience_role_propagation(void) {
 
   sfu_peer_session_t *s = sfu_session_table_get_or_create(&table, &addr, addr_len);
   assert(s != NULL);
-  s->is_audience = aud->is_audience;
-  assert(s->is_audience == true);
+  atomic_store(&s->is_audience, aud->is_audience);
+  assert(atomic_load(&s->is_audience) == true);
 
   /* Guard: audience sessions are never a publish source. */
   assert(sfu_session_subscriptions_acquire(s) == NULL);
 
   /* Speaker sessions keep normal (non-NULL once published) semantics; with no
    * published snapshot yet, acquire is NULL but the flag itself is clear. */
-  s->is_audience = spk->is_audience;
-  assert(s->is_audience == false);
+  atomic_store(&s->is_audience, spk->is_audience);
+  assert(atomic_load(&s->is_audience) == false);
 
   sfu_session_release(s);
   sfu_session_table_destroy(&table);


### PR DESCRIPTION
## Audience / speaker role completion

Implements the three remaining audience-role items on top of latest `develop`.

### 1. Audience only listens — no costly media processing

- Audience **RTP** is dropped after peer/session validation but **before** SRTP decrypt, RTP parsing, SVC analysis, packet cloning, and fanout.
- Audience **RTCP** still flows, so TWCC/NACK/PLI feedback continues for tracks the audience receives.
- Adds `audience_rtp_drop` metric.
- Initial and server-initiated SDP offers now mark the audience local audio/video m-lines as `a=inactive`; speaker local m-lines remain `a=recvonly`.

### 2. Correct asymmetric room topology

The previous `receivers` snapshot served two contradictory responsibilities: router fanout targets and SDP remote sources. This PR separates them:

- **Fanout targets** (new `fanout_targets`) are publisher-owned and used only by `sfu_router_forward`.
  - A speaker forwards to all participants.
  - An audience has no fanout targets and cannot publish.
- **Remote sources** (existing `receivers`, now explicitly subscriber-owned) are used only by SDP.
  - Every participant, including audience, sees all current speakers in SDP.
  - No participant sees audience as a remote source.

This preserves stable remote MIDs while removing redundant reverse snapshots.

### 3. Runtime self-service role transitions

Wire protocol:

    {"type":"raise_hand"}
    {"type":"role_change","role":"speaker"}
    {"type":"role_change","role":"audience"}

- Requests act only on the caller own bound session.
- `raise_hand` is a self-service promotion request (equivalent to `role_change` speaker).
- **Promotion** rebuilds new speaker fanout targets/source visibility and triggers room renegotiation.
- **Demotion** removes the former speaker from remote source/fanout paths while preserving their ability to receive other speakers.
- Session role is atomic for signaling ↔ worker-thread visibility.
- Success response: `{"type":"role_changed","user_id":"…","role":"speaker|audience"}`.

### Tests

- Added room-graph coverage for speaker/audience asymmetry, promotion, and demotion.
- Added SDP coverage for initial and renegotiation local m-line role directions.
- Updated role-propagation session test for atomic state.
- Build passed; full CTest suite: **29/29 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)